### PR TITLE
Resolver: get around MongoDB 16MB document size limit

### DIFF
--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -27,13 +27,5 @@ jobs:
           cd docker && bash ./dockbuild.sh
 
       - name: Build & Run Python Tests via Docker
-        run: cd docker && ./testall python
+        run: scripts/testall.docker python
 
-      - name: Test Java via Docker
-        run: cd docker && ./testall java
-
-      - name: Build Angular Code
-        run: cd docker && ./makedist angular
-
-      - name: Run Angular Tests
-        run: cd docker && ./testall angular

--- a/python/nistoar/pdr/describe/__init__.py
+++ b/python/nistoar/pdr/describe/__init__.py
@@ -1,4 +1,5 @@
 """
 a module for accessing public metadata about PDR data objects.
 """
-from .rmm import MetadataClient, RMMServerError, RMMClientError, IDNotFound
+from .rmm import RMMServerError, RMMClientError, IDNotFound
+from .hybrid import MetadataClient

--- a/python/nistoar/pdr/describe/altbig.py
+++ b/python/nistoar/pdr/describe/altbig.py
@@ -1,0 +1,270 @@
+"""
+a module for accessing public metadata about PDR objects via the Resource 
+Metadata Manager (RMM).  
+"""
+import os, sys, shutil, logging, json, re
+from collections import OrderedDict
+from collections.abc import Mapping
+
+import requests
+
+from ..exceptions import PDRServiceException, PDRServerError, IDNotFound, StateException
+from .. import constants as const
+from nistoar.nerdm.utils import Version
+from nistoar.pdr.utils import read_json
+
+_ark_id_re = re.compile(const.ARK_ID_PAT)
+VER_DELIM  = const.RELHIST_EXTENSION
+FILE_DELIM = const.FILECMP_EXTENSION
+LINK_DELIM = const.LINKCMP_EXTENSION
+AGG_DELIM  = const.AGGCMP_EXTENSION
+OLD_COMP_DELIM = "/cmps"
+
+class MetadataClient(object):
+    """
+    a client interface for retrieving metadata from flat JSON files on disk.  The purpose of this 
+    "database" is to hold records that are too big for the MongoDB database with its current 
+    collection model.  This will work best when it only contains a few records.  
+
+    In this implementation, the files are found under a single directory.  Each file contains a
+    full NERDm Resource record (with components) with a file name of the form "[PDRID]-v[VER].json"
+    (where VER is an _-delimited version).  
+    """
+    _fname_re = re.compile(r'-v(\d+_\d+_\d+).json$')
+
+    def __init__(self, cachedir: str):
+        """
+        :param str cachedir:  directory where the NERDm JSON files can be found.
+        """
+        self._root = cachedir
+        if not os.path.isdir(self._root):
+            raise StateException("Metadata directory: %s: not found" % self._root)
+
+        # index the contents
+        self._versions = {}
+        self._ediids = {}
+        # self._index_cache()
+
+    def _index_cache(self):
+        latest = {}
+        for k in self._versions:
+            if 'latest' in self._versions[k]:
+                f = os.path.basename(self._versions[k]['latest'])
+                m = self._fname_re(f)
+                if m:
+                    latest[k] = Version(m.group(1).replace('_', '.'))
+
+        for f in os.listdir(self._root):
+            m = self._fname_re.search(f)
+            if m:
+                id = f[:m.start(0)]
+                ver = m.group(1).replace('_', '.')
+                f = os.path.join(self._root, f)
+                if id not in self._versions:
+                    self._versions[id] = {}
+                self._versions[id][ver] = f
+
+                ver = Version(ver)
+                if id not in latest or latest[id] < ver:
+                    latest[id] = ver
+
+                if len(id) > 30:
+                    # Note: ediid used in name; we should avoid this issue for performance reasons
+                    ediid = id
+                    try:
+                        nerdm = read_json(f)
+                        idm = _ark_id_re.match(nerdm.get('@id',''))
+                        if idm:
+                            id = idm.group(const.ARK_ID_DS_GRP)
+                            self._ediids[id] = id
+                            if id not in self._versions:
+                                self._versions[id] = {}
+                            self._versions[id][str(ver)] = f
+
+                            if id not in latest or latest[id] < ver:
+                                latest[id] = ver
+                    except (ValueError, TypeError):
+                        # skip corrupted file
+                        pass
+
+        for id in latest:
+            if id not in self._versions:
+                self._versions[id] = {}
+            if str(latest[id]) in self._versions[id]:
+                self._versions[id]['latest'] = self._versions[id][str(latest[id])]
+
+    def describe(self, id: str, version: str=None) -> Mapping:
+        """
+        return the NERDm metadata describing the data entity with the given ID.  The identifier
+        can refer to a dataset, a version of a dataset, a dataset release history, or a dataset
+        component (e.g. a file in a dataset).  
+        :param str id:  the identifier for the desired item.  If it does not start with "ark:",
+                        the respository's native ARK base is assumed. 
+        :param str version:  a particular version of the dataset.  If the given `id` already 
+                        refers to a particular version, this parameter is ignored.  If not given,
+                        then the ID determines if a particular version or the latest version is 
+                        retrieved.  
+        :return:  the NERDm metadata describing the identified thing
+                  :rtype: Mapping
+        :raises IDNotFound:  if the identifier is unknown
+        """
+        find = id.rstrip('/')  # trailing slash treated as superfluous
+        if find.endswith(FILE_DELIM):
+            # for now, treat an ID ending in "/pdr:f" equivalently to a dataset id
+            find = find[:-1*len(FILE_DELIM)]
+
+        if not find.startswith("ark:"):
+            find = "ark:/" + const.ARK_NAAN + '/' + find
+
+        idm = _ark_id_re.match(find)
+        if not idm:
+            # don't bother if it's not a compliant ARK ID
+            raise IDNotFound(id)
+
+        if not idm.group(const.ARK_ID_PATH_GRP) and not idm.group(const.ARK_ID_PART_GRP):
+            # it appears to be simply a dataset ID (there's nothing past the dataset part)
+            return self._describe_version(idm.group(const.ARK_ID_DS_GRP), version, id)
+
+        if idm.group(const.ARK_ID_PATH_GRP) == VER_DELIM:
+            # ends with "/pdr:v" 
+            return self._describe_releases(idm.group(const.ARK_ID_DS_GRP), id)
+
+        if not idm.group(const.ARK_ID_PART_GRP) and idm.group(const.ARK_ID_PATH_GRP).startswith(VER_DELIM+'/'):
+            fields = idm.group(const.ARK_ID_PATH_GRP).split('/', 3)
+            version = fields[2]
+            if len(fields) < 4:
+                # we want a version of a dataset
+                return self._describe_version(idm.group(const.ARK_ID_DS_GRP), version, id)
+
+        return self._describe_component(idm, version, id)
+
+    def _describe_releases(self, id, reqid=None):
+        if not reqid:
+            reqid = id
+
+        rec = self._describe_latest_ds(id, reqid)
+
+        if not rec or not 'releaseHistory' in rec:
+            raise IDNotFound(reqid)
+
+        if 'components' in rec:
+            del rec['components']
+        rec['hasRelease'] = rec['releaseHistory'].get('hasRelease',[])
+        rec['@id'] = rec['@id'] + const.RELHIST_EXTENSION
+        return rec
+        
+
+    def _describe_version(self, id, version, reqid=None):
+        if not reqid:
+            reqid = id
+
+        if not version:
+            version = 'latest'
+
+        out = self._get(id, version, reqid)
+        if version == 'latest':
+            idm = _ark_id_re.match(out.get('@id',''))
+            if idm and idm.group(const.ARK_ID_PATH_GRP):
+                out['@id'] = out['@id'][:idm.start(const.ARK_ID_PATH_GRP)]
+
+        return out
+
+    def _describe_latest_ds(self, id, reqid=None):
+        return self._describe_version(id, 'latest', reqid)
+        
+    def _describe_component(self, idm, version, reqid=None):
+        if not reqid:
+            reqid = idm.group()
+
+        dsid = idm.group()[:idm.start(const.ARK_ID_PATH_GRP)]
+        cmpid = idm.group()[idm.start(const.ARK_ID_PATH_GRP):]
+        id = idm.group(const.ARK_ID_DS_GRP)
+
+        if idm.group(const.ARK_ID_PATH_GRP).startswith(VER_DELIM+'/'):
+            parts = idm.group(const.ARK_ID_PATH_GRP).split('/', 3)
+            if len(parts) > 2 and parts[1] == VER_DELIM.lstrip('/'):
+                version = parts[2]
+                cmpid = idm.group(const.ARK_ID_PART_GRP) or ''
+                if len(parts) > 3:
+                    cmpid = '/' + parts[3] + cmpid
+
+        dsmd = self._describe_version(id, version)
+
+        # extract the requested component
+        find = cmpid.lstrip('/')
+        cmpmd = [c for c in dsmd.get('components',[]) if c.get('@id') == find]
+
+        # try some alternatives (support old file component delimiter)
+        if len(cmpmd) == 0:
+            find = None
+            if cmpid.startswith(FILE_DELIM+'/'):
+                find = "cmps" + cmpid[len(FILE_DELIM):]
+            elif cmpid.startswith('/cmps/'):
+                find = FILE_DELIM + cmpid[len('/cmps'):]
+                find = find.lstrip('/')
+            if find:
+                cmpmd = [c for c in dsmd.get('components',[]) if c.get('@id') == find]
+
+        if len(cmpmd) == 0:
+            raise IDNotFound(reqid)
+
+        # tweak the meta-metadata on its way out the door
+        if version:
+            dsid += VER_DELIM + '/' + version
+        cmpmd[0]['isPartOf'] = dsid
+        if cmpmd[0]['@id'][0] != '/' and cmpmd[0]['@id'][0] != '#':
+            dsid += '/'
+        cmpmd[0]['@id'] = dsid + cmpmd[0]['@id']
+        if '@context' in dsmd:
+            cmpmd[0]['@context'] = dsmd['@context']
+        if 'version' in dsmd and 'version' not in cmpmd[0]:
+            cmpmd[0]['version'] = dsmd['version']
+        return cmpmd[0]
+
+    def exists(self, id, version: str=None) -> bool:
+        """
+        return true if the specified dataset exists in the "database"
+        """
+        if id.startswith('ark:'):
+            idm = _ark_id_re.match(id)
+            if idm:
+                id = idm.group(const.ARK_ID_DS_GRP)
+            if idm.group(const.ARK_ID_PATH_GRP) and \
+               idm.group(const.ARK_ID_PATH_GRP).startswith(VER_DELIM):
+                fields = idm.group(const.ARK_ID_PATH_GRP).split('/')
+                version = fields[2]
+
+        if not self._versions:
+            if version and version != 'latest':
+                fpath = os.path.join(self._root, "%s-v%s.json" % (id, version.replace('.', '_')))
+                if os.path.isfile(fpath):
+                    return True
+            self._index_cache()
+
+        if id not in self._versions:
+            return False
+        if version: 
+            return version in self._versions[id]
+        return True
+
+    def _get(self, aipid, version, reqid):
+        if not self._versions:
+            if version != 'latest':
+                fpath = os.path.join(self._root, "%s-v%s.json" % (aipid, version.replace('.', '_')))
+                if os.path.isfile(fpath):
+                    return self._read_file(fpath, reqid)
+            self._index_cache()
+
+        return self._read_file(self._versions.get(aipid, {}).get(version), reqid)
+            
+    def _read_file(self, fpath, reqid):
+        if not fpath or not os.path.isfile(fpath):
+            raise IDNotFound(reqid)
+
+        try:
+            return read_json(fpath)
+        except (ValueError, IOError) as ex:
+            raise RMMServerError(id, message="Failed to read NERDm record as JSON: " % str(ex))
+
+    
+        

--- a/python/nistoar/pdr/describe/altbig.py
+++ b/python/nistoar/pdr/describe/altbig.py
@@ -232,7 +232,8 @@ class MetadataClient(object):
             if idm.group(const.ARK_ID_PATH_GRP) and \
                idm.group(const.ARK_ID_PATH_GRP).startswith(VER_DELIM):
                 fields = idm.group(const.ARK_ID_PATH_GRP).split('/')
-                version = fields[2]
+                if len(fields) > 2:
+                    version = fields[2]
 
         if not self._versions:
             if version and version != 'latest':

--- a/python/nistoar/pdr/describe/hybrid.py
+++ b/python/nistoar/pdr/describe/hybrid.py
@@ -1,0 +1,79 @@
+"""
+a module for accessing public metadata about PDR objects via the Resource 
+Metadata Manager (RMM).  
+"""
+import os, sys, shutil, logging, json, re
+from collections import OrderedDict
+from collections.abc import Mapping
+
+import requests
+
+from . import altbig, rmm
+from ..exceptions import PDRServiceException, PDRServerError, IDNotFound, StateException
+from .. import constants as const
+
+_ark_id_re = re.compile(const.ARK_ID_PAT)
+VER_DELIM  = const.RELHIST_EXTENSION
+FILE_DELIM = const.FILECMP_EXTENSION
+LINK_DELIM = const.LINKCMP_EXTENSION
+AGG_DELIM  = const.AGGCMP_EXTENSION
+OLD_COMP_DELIM = "/cmps"
+
+class MetadataClient(object):
+    """
+    a client interface for retrieving metadata via the RMM or from a file.  This addresses a 
+    MongoDB limitation on the size of a document within a collection (given the RMM's current 
+    collection model).  If a NERDm record is too big for the RMM, a component-less version is 
+    stored instead and the full version is kept on disk.  This client will leverage both 
+    `MetadataClient` instances from the :py:module:`~nistoar.pdr.describe.rmm` and 
+    :py:module:`~nistoar.pdr.describe.altbig` modules to deliver complete record.  
+    """
+
+    def __init__(self, baseurl: str, cachedir: str=None):
+        """
+        setup the client
+        :param str baseurl:   the base URL for the RMM service
+        :param str cachedir:  the root directory for the alternate file cache, if not provided
+                              records will only be retrieved from RMM.
+        """
+        self._rmmcli = rmm.MetadataClient(baseurl)
+        self._altcli = None
+        if cachedir:
+            self._altcli = altbig.MetadataClient(cachedir)
+
+    def alt_record_exists(self, id: str, version: str=None):
+        if not self._altcli:
+            return False
+        return self._altcli.exists(id, version)
+
+    def describe(self, id: str, version: str=None) -> Mapping:
+        """
+        return the NERDm metadata describing the data entity with the given ID.  The identifier
+        can refer to a dataset, a version of a dataset, a dataset release history, or a dataset
+        component (e.g. a file in a dataset).  
+        :param str id:  the identifier for the desired item.  It must begin with an "ark:" prefix
+                        unless it is an (old-style, >30-char) EDI ID.
+        :param str version:  a particular version of the dataset.  If the given `id` already 
+                        refers to a particular version, this parameter is ignored.  If not given,
+                        then the ID determines if a particular version or the latest version is 
+                        retrieved.  
+        :return:  the NERDm metadata describing the identified thing
+                  :rtype: Mapping
+        :raises IDNotFound:  if the identifier is unknown
+        """
+        if self.alt_record_exists(id, version):
+            return self._altcli.describe(id, version)
+        return self._rmmcli.describe(id, version)
+
+    def search(self, query=None, latest=True):
+        """
+        return the NERDm record matching a given query.  All records are returned if a query is not 
+        provided.  
+
+        [Document RMM search paramters]
+
+        :param dict query:  a dictionary whose properties specify the RMM search query parameters by name
+        :param bool latest: if True (default), only the latest versions of resources will be returned; 
+                            otherwise, all matching versions will be returned.
+        """
+        return self._rmmcli.search(query, latest)

--- a/python/nistoar/pdr/preserve/bagit/builder.py
+++ b/python/nistoar/pdr/preserve/bagit/builder.py
@@ -415,10 +415,11 @@ class BagBuilder(PreservationSystem):
 
     @ediid.setter
     def ediid(self, val):
-        if val:
-            self.record("Setting ediid: " + val)
-        elif self._ediid:
-            self.record("Unsetting ediid")
+        if os.path.exists(self.bagdir):
+            if val:
+                self.record("Setting ediid: " + val)
+            elif self._ediid:
+                self.record("Unsetting ediid")
         self._ediid = val
         old = self._upd_ediid(val)
         if self._ediid and self._ediid != old:

--- a/python/nistoar/pdr/public/resolve/handlers/pdrid.py
+++ b/python/nistoar/pdr/public/resolve/handlers/pdrid.py
@@ -30,6 +30,7 @@ class PDRIDHandler(Handler):
         super(PDRIDHandler, self).__init__(path, wsgienv, start_resp, config)
         self._naan = str(self.cfg.get('naan', ark_naan))
         self.log = log
+        self._mdcachedir = self.cfg.get("metadata_cache_dir")
 
     def do_GET(self, path, ashead=False, format=None):
         """
@@ -157,7 +158,7 @@ class PDRIDHandler(Handler):
             if not baseurl:
                 raise ConfigurationException("Missing required configuration: APIs.mdSearch")
             try:
-                nerdm = MetadataClient(baseurl).describe(dsid, version)
+                nerdm = MetadataClient(baseurl, self._mdcachedir).describe(dsid, version)
             except IDNotFound as ex:
                 return self.send_error(404, "Dataset ID Not Found")
             except Exception as ex:
@@ -234,7 +235,7 @@ class PDRIDHandler(Handler):
             if not baseurl:
                 raise ConfigurationException("Missing required configuration: APIs.mdSearch")
             try:
-                nerdm = MetadataClient(baseurl).describe(dsid + const.RELHIST_EXTENSION)
+                nerdm = MetadataClient(baseurl, self._mdcachedir).describe(dsid + const.RELHIST_EXTENSION)
             except IDNotFound as ex:
                 return self.send_error(404, "Dataset ID Not Found")
             except Exception as ex:
@@ -265,7 +266,7 @@ class PDRIDHandler(Handler):
         if not baseurl:
             raise ConfigurationException("Missing required configuration: APIs.mdSearch")
         try:
-            cmpmd = MetadataClient(baseurl).describe(cmpid, version)
+            cmpmd = MetadataClient(baseurl, self._mdcachedir).describe(cmpid, version)
         except IDNotFound as ex:
             return self.send_error(404, "Component ID Not Found")
         except Exception as ex:

--- a/python/tests/nistoar/pdr/describe/test_altbig.py
+++ b/python/tests/nistoar/pdr/describe/test_altbig.py
@@ -1,0 +1,233 @@
+import os, pdb, sys, json, requests, logging, time, re, hashlib, tempfile
+import unittest as test
+
+from nistoar.pdr.describe import altbig
+
+testdir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+datadir = os.path.join(testdir, 'data')
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(testdir)))))
+
+port = 9091
+baseurl = "http://localhost:{0}/".format(port)
+
+testdir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+datadir = os.path.join(testdir, 'data', 'rmm-test-archive', 'versions')
+
+loghdlr = None
+rootlog = None
+tmpdir = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    global tmpdir
+    tmpdir = tempfile.TemporaryDirectory(prefix="_test_altbig.", dir=".")
+    rootlog = logging.getLogger()
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_altbig.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    rootlog.addHandler(loghdlr)
+
+def tearDownModule():
+    global loghdlr
+    global tmpdir
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    tmpdir.cleanup()
+
+class TestAltBigMetadataClient(test.TestCase):
+
+    def setUp(self):
+        self.cli = altbig.MetadataClient(datadir)
+
+    def test_ctor(self):
+        self.assertEqual(self.cli._root, datadir)
+        self.assertTrue(not bool(self.cli._versions))
+
+    def test_index_cache(self):
+        self.assertTrue(not bool(self.cli._versions))
+        self.cli._index_cache()
+        self.assertTrue(bool(self.cli._versions))
+
+        for id in "19A9D7193F868BDDE0531A57068151D2431 1E0F15DAAEFB84E4E0531A5706813DD8436 1E651A532AFD8816E0531A570681A662439 mds2-2106 mds2-2107 mds2-2110 mds2-7223 mds00qdrz9 mds00sxbvh mds003r0x6".split():
+            self.assertIn(id, self.cli._versions)
+        self.assertEqual(len(self.cli._versions), 10)        
+
+        self.assertEqual(len(self.cli._versions['19A9D7193F868BDDE0531A57068151D2431']), 2)
+        self.assertEqual(len(self.cli._versions['1E0F15DAAEFB84E4E0531A5706813DD8436']), 2)
+        self.assertEqual(len(self.cli._versions['1E651A532AFD8816E0531A570681A662439']), 5)
+        self.assertEqual(len(self.cli._versions['mds00qdrz9']), 2)
+        self.assertEqual(len(self.cli._versions['mds003r0x6']), 2)
+        self.assertEqual(len(self.cli._versions['mds00sxbvh']), 5)
+        self.assertEqual(len(self.cli._versions['mds2-2106']), 8)
+        self.assertEqual(len(self.cli._versions['mds2-2107']), 2)
+        self.assertEqual(len(self.cli._versions['mds2-2110']), 3)
+        self.assertEqual(len(self.cli._versions['mds2-7223']), 3)
+
+    def test_exists(self):
+        self.assertTrue(not self.cli._versions, "Index unintentionally created")
+
+        self.assertTrue(self.cli.exists('mds2-2106', '1.5.0'))
+        self.assertTrue(not self.cli._versions, "Index unintentionally created")
+
+        self.assertTrue(self.cli.exists('mds2-2107'))
+        self.assertTrue(self.cli._versions)
+
+        self.assertTrue(self.cli.exists('19A9D7193F868BDDE0531A57068151D2431'))
+        self.assertTrue(self.cli.exists('1E0F15DAAEFB84E4E0531A5706813DD8436'))
+        self.assertTrue(self.cli.exists('1E651A532AFD8816E0531A570681A662439'))
+
+        self.assertTrue(not self.cli.exists('mds2-2108'))
+        self.assertTrue(self.cli.exists('mds2-7223'))
+
+    def test_describe_ark(self):
+        data = self.cli.describe("ark:/88434/mds003r0x6")
+        self.assertEqual(data['@id'], 'ark:/88434/mds003r0x6')
+        self.assertEqual(data['ediid'], '1E0F15DAAEFB84E4E0531A5706813DD8436')
+
+        data = self.cli.describe("ark:/88434/mds2-2110")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2110')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2110')
+
+    def test_describe_no_ark(self):
+        data = self.cli.describe("mds003r0x6")
+        self.assertEqual(data['@id'], 'ark:/88434/mds003r0x6')
+        self.assertEqual(data['ediid'], '1E0F15DAAEFB84E4E0531A5706813DD8436')
+
+        data = self.cli.describe("mds2-2110")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2110')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2110')
+
+    def test_describe_ark_version(self):
+        self.assertFalse(self.cli._versions, "Index unintentionally created")
+
+        data = self.cli.describe("ark:/88434/mds2-2106", "1.6.0")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.6.0')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2106')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 7)
+        self.assertFalse(self.cli._versions, "Index unintentionally created")
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.4")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.4')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
+        self.assertTrue(self.cli._versions)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.1")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.1')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.1')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 2)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.4")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.4')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.1")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.1')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.1')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 2)
+
+        with self.assertRaises(altbig.IDNotFound):
+            data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.8")
+        with self.assertRaises(altbig.IDNotFound):
+            data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.8", "1.0.1")
+
+    def test_describe_releases(self):
+        data = self.cli.describe("ark:/88434/mds2-2110/pdr:v")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2110/pdr:v')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2110')
+        self.assertEqual(data['version'], '1.0.1')
+        self.assertEqual(len(data['hasRelease']), 2)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(len(data['hasRelease']), 5)
+
+    def test_describe_file_component(self):
+        data = self.cli.describe("ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:f/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:v/1.4.0/pdr:f/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.4.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.4.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+
+    def test_describe_part_component(self):
+        data = self.cli.describe("ark:/88434/mds2-2106#doi:10.18434/M32106")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106#doi:10.18434/M32106")
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds2-2106')
+        self.assertIn('@context', data)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh#srd/nist-special-database-18")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds00sxbvh#srd/nist-special-database-18")
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds00sxbvh')
+        self.assertIn('@context', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:v/1.3.0#doi:10.18434/M32106")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106/pdr:v/1.3.0#doi:10.18434/M32106")
+        self.assertEqual(data['version'], '1.3.0')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds2-2106/pdr:v/1.3.0')
+        self.assertIn('@context', data)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.3#srd/nist-special-database-18")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds00sxbvh/pdr:v/1.0.3#srd/nist-special-database-18")
+        self.assertEqual(data['version'], '1.0.3')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.3')
+        self.assertIn('@context', data)
+
+if __name__ == '__main__':
+    test.main()
+
+
+
+
+

--- a/python/tests/nistoar/pdr/describe/test_altbig.py
+++ b/python/tests/nistoar/pdr/describe/test_altbig.py
@@ -96,10 +96,14 @@ class TestAltBigMetadataClient(test.TestCase):
         data = self.cli.describe("mds003r0x6")
         self.assertEqual(data['@id'], 'ark:/88434/mds003r0x6')
         self.assertEqual(data['ediid'], '1E0F15DAAEFB84E4E0531A5706813DD8436')
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(not any(["/_v/" in u for u in dlus]))
 
         data = self.cli.describe("mds2-2110")
         self.assertEqual(data['@id'], 'ark:/88434/mds2-2110')
         self.assertEqual(data['ediid'], 'ark:/88434/mds2-2110')
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(not any(["/_v/" in u for u in dlus]))
 
     def test_describe_ark_version(self):
         self.assertFalse(self.cli._versions, "Index unintentionally created")
@@ -110,6 +114,8 @@ class TestAltBigMetadataClient(test.TestCase):
         self.assertEqual(data['version'], '1.6.0')
         self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 7)
         self.assertFalse(self.cli._versions, "Index unintentionally created")
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(all(["/_v/" in u for u in dlus]))
 
         data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.4")
         self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.4')
@@ -117,24 +123,48 @@ class TestAltBigMetadataClient(test.TestCase):
         self.assertEqual(data['version'], '1.0.4')
         self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
         self.assertTrue(self.cli._versions)
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(all(["/_v/" in u for u in dlus]))
 
         data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.1")
         self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.1')
         self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
         self.assertEqual(data['version'], '1.0.1')
         self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 2)
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(not any(["/_v/" in u for u in dlus]))  # non-distrib svc urls
 
         data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.4")
         self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.4')
         self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
         self.assertEqual(data['version'], '1.0.4')
         self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(not any(["/_v/" in u for u in dlus]))  # non-distrib svc urls
 
         data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.1")
         self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.1')
         self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
         self.assertEqual(data['version'], '1.0.1')
         self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 2)
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(not any(["/_v/" in u for u in dlus]))
+
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:v/1.3.0")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.3.0')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2106')
+        self.assertEqual(data['version'], '1.3.0')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 4)
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(all(["/_v/" in u for u in dlus]))
+
+        data = self.cli.describe("ark:/88434/mds2-2106")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2106')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 7)
+        dlus = [c['downloadURL'] for c in data.get('components', []) if 'downloadURL' in c]
+        self.assertTrue(not any(["/_v/" in u for u in dlus]))
 
         with self.assertRaises(altbig.IDNotFound):
             data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.8")
@@ -159,6 +189,8 @@ class TestAltBigMetadataClient(test.TestCase):
         self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv')
         self.assertEqual(data['version'], '1.6.0')
         self.assertIn('@context', data)
+        self.assertIn('downloadURL', data)
+        self.assertNotIn('/_v/', data['downloadURL'])
         self.assertNotIn('components', data)
         self.assertNotIn('releaseHistory', data)
         self.assertNotIn('versionHistory', data)
@@ -167,6 +199,8 @@ class TestAltBigMetadataClient(test.TestCase):
         self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv')
         self.assertEqual(data['version'], '1.6.0')
         self.assertIn('@context', data)
+        self.assertIn('downloadURL', data)
+        self.assertNotIn('/_v/', data['downloadURL'])
         self.assertNotIn('components', data)
         self.assertNotIn('releaseHistory', data)
         self.assertNotIn('versionHistory', data)
@@ -175,6 +209,8 @@ class TestAltBigMetadataClient(test.TestCase):
         self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/NIST_NPL_InterlabData2019.csv')
         self.assertEqual(data['version'], '1.4.0')
         self.assertIn('@context', data)
+        self.assertIn('downloadURL', data)
+        self.assertIn('/_v/', data['downloadURL'])
         self.assertNotIn('components', data)
         self.assertNotIn('releaseHistory', data)
         self.assertNotIn('versionHistory', data)

--- a/python/tests/nistoar/pdr/describe/test_hybrid.py
+++ b/python/tests/nistoar/pdr/describe/test_hybrid.py
@@ -1,0 +1,274 @@
+import os, pdb, sys, json, requests, logging, time, re, hashlib
+import unittest as test
+
+from nistoar.testing import *
+from nistoar.pdr.describe import rmm, altbig, hybrid
+from nistoar.pdr.utils import read_json, write_json
+
+testdir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+datadir = os.path.join(testdir, 'data', 'rmm-test-archive', 'versions')
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(testdir)))))
+
+port = 9091
+baseurl = "http://localhost:{0}/".format(port)
+
+cachedir = None
+def setup_cache():
+    global cachedir
+    ensure_tmpdir()
+    cachedir = os.path.join(tmpdir(), "cache")
+    os.mkdir(cachedir)
+    for f in "mds2-2106-v1_5_0.json mds2-2106-v1_6_0.json".split():
+        nerd = read_json(os.path.join(datadir, f))
+        nerd['big'] = True
+        write_json(nerd, os.path.join(cachedir, f))
+
+def startService(authmeth=None):
+    tdir = tmpdir()
+    srvport = port
+    if authmeth == 'header':
+        srvport += 1
+    pidfile = os.path.join(tdir,"simsrv"+str(srvport)+".pid")
+    
+    wpy = "python/tests/nistoar/pdr/describe/sim_describe_svc.py"
+    cmd = "uwsgi --daemonize {0} --plugin python3 --http-socket :{1} " \
+          "--wsgi-file {2} --pidfile {3}"
+    cmd = cmd.format(os.path.join(tdir,"simsrv.log"), srvport,
+                     os.path.join(basedir, wpy), pidfile)
+    os.system(cmd)
+    time.sleep(0.5)
+
+def stopService(authmeth=None):
+    tdir = tmpdir()
+    srvport = port
+    if authmeth == 'header':
+        srvport += 1
+    pidfile = os.path.join(tdir,"simsrv"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                                 "simsrv"+str(srvport)+".pid"))
+    os.system(cmd)
+    time.sleep(1)
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    ensure_tmpdir()
+    rootlog = logging.getLogger()
+    loghdlr = logging.FileHandler(os.path.join(tmpdir(),"test_simsrv.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    rootlog.addHandler(loghdlr)
+    startService()
+    setup_cache()
+
+def tearDownModule():
+    global cachedir
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    stopService()
+    rmtmpdir()
+
+class TestMetadataClient(test.TestCase):
+
+    def setUp(self):
+        self.baseurl = baseurl
+        self.cli = hybrid.MetadataClient(self.baseurl, cachedir)
+
+    def test_describe_ark(self):
+        data = self.cli.describe("ark:/88434/mds003r0x6")
+        self.assertEqual(data['@id'], 'ark:/88434/mds003r0x6')
+        self.assertEqual(data['ediid'], '1E0F15DAAEFB84E4E0531A5706813DD8436')
+
+        data = self.cli.describe("ark:/88434/mds2-2110")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2110')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2110')
+
+    def test_no_cache(self):
+        self.cli = hybrid.MetadataClient(self.baseurl)
+
+        data = self.cli.describe("ark:/88434/mds2-2106", "1.6.0")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.6.0')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2106')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 7)
+        self.assertTrue(not data.get('big'))
+
+    def test_describe_ark_version(self):
+        data = self.cli.describe("ark:/88434/mds2-2106", "1.6.0")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.6.0')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2106')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 7)
+        self.assertTrue(data.get('big'))
+
+        data = self.cli.describe("ark:/88434/mds2-2106", "1.5.0")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.5.0')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2106')
+        self.assertEqual(data['version'], '1.5.0')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 6)
+        self.assertTrue(data.get('big'))
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.4")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.4')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
+        self.assertTrue(not data.get('big'))
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.1")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.1')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.1')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
+        self.assertTrue(not data.get('big'))
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.4")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.4')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
+        self.assertTrue(not data.get('big'))
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.1")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.1')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.1')
+        self.assertEqual(len(data.get('releaseHistory',{}).get('hasRelease',[])), 5)
+        self.assertTrue(not data.get('big'))
+
+        with self.assertRaises(rmm.IDNotFound):
+            data = self.cli.describe("ark:/88434/mds00sxbvh", "1.0.8")
+        with self.assertRaises(rmm.IDNotFound):
+            data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.8", "1.0.1")
+
+    def test_describe_ediid(self):
+        data = self.cli.describe("1E0F15DAAEFB84E4E0531A5706813DD8436")
+        self.assertEqual(data['@id'], 'ark:/88434/mds003r0x6')
+        self.assertEqual(data['ediid'], '1E0F15DAAEFB84E4E0531A5706813DD8436')
+
+        with self.assertRaises(rmm.IDNotFound):
+            data = self.cli.describe("mds2-2110")
+
+    def test_describe_ediid_version(self):
+        data = self.cli.describe("1E651A532AFD8816E0531A570681A662439", "1.0.4")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.4')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.4')
+
+        data = self.cli.describe("1E651A532AFD8816E0531A570681A662439", "1.0.1")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.1')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.1')
+
+        with self.assertRaises(rmm.IDNotFound):
+            data = self.cli.describe("1E651A532AFD8816E0531A570681A662439", "1.0.8")
+
+    def test_describe_releases(self):
+        data = self.cli.describe("ark:/88434/mds2-2110/pdr:v")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2110/pdr:v')
+        self.assertEqual(data['ediid'], 'ark:/88434/mds2-2110')
+        self.assertEqual(data['version'], '1.0.1')
+        self.assertEqual(len(data['hasRelease']), 2)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v")
+        self.assertEqual(data['@id'], 'ark:/88434/mds00sxbvh/pdr:v')
+        self.assertEqual(data['ediid'], '1E651A532AFD8816E0531A570681A662439')
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(len(data['hasRelease']), 5)
+
+    def test_search(self):
+        data = self.cli.search()
+        self.assertEqual(len(data), 7)
+
+        ids = [d['ediid'] for d in data if 'ediid' in d]
+        self.assertIn("ark:/88434/mds2-2106", ids)
+        self.assertIn("ark:/88434/mds2-2107", ids)
+        self.assertIn("ark:/88434/mds2-2110", ids)
+        self.assertIn("ark:/88434/mds2-7223", ids)
+        self.assertIn("1E651A532AFD8816E0531A570681A662439", ids)
+        self.assertIn("19A9D7193F868BDDE0531A57068151D2431", ids)
+        self.assertIn("1E0F15DAAEFB84E4E0531A5706813DD8436", ids)
+        
+    def test_describe_file_component(self):
+        data = self.cli.describe("ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:f/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:v/1.4.0/pdr:f/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.4.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/NIST_NPL_InterlabData2019.csv")
+        self.assertEqual(data['@id'], 'ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/NIST_NPL_InterlabData2019.csv')
+        self.assertEqual(data['version'], '1.4.0')
+        self.assertIn('@context', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+
+    def test_describe_part_component(self):
+        data = self.cli.describe("ark:/88434/mds2-2106#doi:10.18434/M32106")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106#doi:10.18434/M32106")
+        self.assertEqual(data['version'], '1.6.0')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds2-2106')
+        self.assertIn('@context', data)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh#srd/nist-special-database-18")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds00sxbvh#srd/nist-special-database-18")
+        self.assertEqual(data['version'], '1.0.4')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds00sxbvh')
+        self.assertIn('@context', data)
+        
+        data = self.cli.describe("ark:/88434/mds2-2106/pdr:v/1.3.0#doi:10.18434/M32106")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106/pdr:v/1.3.0#doi:10.18434/M32106")
+        self.assertEqual(data['version'], '1.3.0')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds2-2106/pdr:v/1.3.0')
+        self.assertIn('@context', data)
+
+        data = self.cli.describe("ark:/88434/mds00sxbvh/pdr:v/1.0.3#srd/nist-special-database-18")
+        self.assertNotIn('components', data)
+        self.assertNotIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['@id'], "ark:/88434/mds00sxbvh/pdr:v/1.0.3#srd/nist-special-database-18")
+        self.assertEqual(data['version'], '1.0.3')
+        self.assertEqual(data['isPartOf'], 'ark:/88434/mds00sxbvh/pdr:v/1.0.3')
+        self.assertIn('@context', data)
+        
+
+if __name__ == '__main__':
+    test.main()
+
+

--- a/python/tests/nistoar/pdr/public/resolve/handlers/test_pdrid_hybrid.py
+++ b/python/tests/nistoar/pdr/public/resolve/handlers/test_pdrid_hybrid.py
@@ -1,0 +1,328 @@
+import os, pdb, sys, json, requests, logging, time, re, hashlib
+import unittest as test
+
+from nistoar.testing import *
+from nistoar.pdr.public.resolve.handlers.pdrid import PDRIDHandler
+from nistoar.pdr.utils import read_json, write_json
+from nistoar.pdr import constants as const
+
+testdir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+desctestdir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(testdir))), "describe")
+datadir = os.path.join(desctestdir, 'data', 'rmm-test-archive', 'versions')
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(testdir)))))))
+
+port = 9091
+baseurl = "http://localhost:{0}/".format(port)
+VER_DELIM  = const.RELHIST_EXTENSION
+DSVER_DELIM = "/_v"
+verpath_re = re.compile(VER_DELIM+r'/\d+\.\d+.\d+')
+dsverpath_re = re.compile(DSVER_DELIM+r'/\d+\.\d+.\d+')
+
+cachedir = None
+def setup_cache():
+    global cachedir
+    ensure_tmpdir()
+    cachedir = os.path.join(tmpdir(), "cache")
+    os.mkdir(cachedir)
+    for f in "mds2-2106-v1_5_0.json mds2-2106-v1_6_0.json".split():
+        nerd = read_json(os.path.join(datadir, f))
+        nerd['big'] = True
+        if VER_DELIM in nerd.get('@id',''):
+            nerd['@id'] = verpath_re.sub('', nerd['@id'])
+        for cmp in nerd.get('components', []):
+            if DSVER_DELIM in cmp.get('downloadURL',''):
+                cmp['downloadURL'] = dsverpath_re.sub('', cmp['downloadURL'])
+            if VER_DELIM in cmp.get('downloadURL',''):
+                cmp['downloadURL'] = verpath_re.sub('', cmp['downloadURL'])
+        write_json(nerd, os.path.join(cachedir, f))
+
+def startService(authmeth=None):
+    adir = artifactdir(__name__)
+    tdir = tmpdir()
+    srvport = port
+    if authmeth == 'header':
+        srvport += 1
+    pidfile = os.path.join(tdir,"simsrv"+str(srvport)+".pid")
+    
+    wpy = "python/tests/nistoar/pdr/describe/sim_describe_svc.py"
+    cmd = "uwsgi --daemonize {0} --plugin python3 --http-socket :{1} " \
+          "--wsgi-file {2} --pidfile {3}"
+    cmd = cmd.format(os.path.join(adir,"simsrv.log"), srvport,
+                     os.path.join(basedir, wpy), pidfile)
+    os.system(cmd)
+    time.sleep(0.5)
+
+def stopService(authmeth=None):
+    tdir = tmpdir()
+    srvport = port
+    if authmeth == 'header':
+        srvport += 1
+    pidfile = os.path.join(tdir,"simsrv"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir, "simsrv"+str(srvport)+".pid"))
+    os.system(cmd)
+    time.sleep(1)
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    ensure_tmpdir()
+    setup_cache()
+    rootlog = logging.getLogger()
+    loghdlr = logging.FileHandler(os.path.join(artifactdir(__name__),"test_simsrv.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    rootlog.addHandler(loghdlr)
+    startService()
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    stopService()
+    rmtmpdir()
+
+class TestPDRIDHandler(test.TestCase):
+
+    def setUp(self):
+        self.cfg = {
+            "metadata_cache_dir": os.path.join(tmpdir(), "cache"),
+            "locations": {
+                "landingPageService": "https://data.nist.gov/pdr/od/id/",
+                "resolverService":    "https://data.nist.gov/od/id/"
+            },
+            "APIs": {
+                "mdSearch":    baseurl
+            }                
+        }
+        self.resp = []
+
+    def tearDown(self):
+        self.resp = []
+
+    def start(self, status, headers=None, extup=None):
+        self.resp.append(status)
+        for head in headers:
+            self.resp.append("{0}: {1}".format(head[0], head[1]))
+
+    def gethandler(self, path, req):
+        return PDRIDHandler(path, req, self.start, self.cfg, rootlog)
+
+    def tostr(self, resplist):
+        return [e.decode() for e in resplist]
+
+    def test_get_dataset_nerdm(self):
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2107",
+            'HTTP_ACCEPT': "application/json"
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: "+req['HTTP_ACCEPT'])
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 1584")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2107")
+        self.assertIn('components', data)
+        self.assertTrue(not data.get('big'))
+
+        self.resp = []
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2106"
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: application/json")
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 9334")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106")
+        self.assertEqual(data['version'], "1.6.0")
+        self.assertEqual(len(data.get('releaseHistory', {}).get('hasRelease', [])), 7)
+        self.assertIn('components', data)
+        self.assertTrue(data.get('big'))
+        
+    def test_get_releaseset(self):
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2106/pdr:v/"
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: application/json")
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 3708")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106/pdr:v")
+        self.assertNotIn('components', data)
+        self.assertIn('hasRelease', data)
+        self.assertEqual(len(data['hasRelease']), 7)
+
+    def test_resolve_dataset_version(self):
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2106/pdr:v/1.6.0"
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: application/json")
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 9382")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106/pdr:v/1.6.0")
+        self.assertIn('components', data)
+        self.assertTrue(data.get('big'))
+
+        self.resp = []
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2106/pdr:v/1.3.0"
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: application/json")
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 9460")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106/pdr:v/1.3.0")
+        self.assertEqual(data['version'], "1.3.0")
+        self.assertEqual(len(data.get('releaseHistory', {}).get('hasRelease', [])), 7)
+        self.assertIn('components', data)
+        self.assertTrue(not data.get('big'))
+
+
+    def test_resolve_ediid(self):
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "1E0F15DAAEFB84E4E0531A5706813DD8436"
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: application/json")
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 3320")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds003r0x6")
+        self.assertIn('components', data)
+
+    def test_get_file_comp(self):
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2106/pdr:f/Readme.txt",
+            'QUERY_STRING': 'format=nerdm'
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: application/json")
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 1017")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106/cmps/Readme.txt")
+        self.assertEqual(data['downloadURL'], "https://data.nist.gov/od/ds/mds2-2106/Readme.txt")
+        self.assertEqual(data['isPartOf'], "ark:/88434/mds2-2106")
+        self.assertEqual(data['version'], "1.6.0")
+        self.assertIn('@context', data)
+
+        self.resp = []
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2106/pdr:v/1.4.0/pdr:f/Readme.txt",
+            'QUERY_STRING': 'format=nerdm'
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "200 ")
+        ct = [h for h in self.resp if h.startswith("Content-Type:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Type: application/json")
+        ct = [h for h in self.resp if h.startswith("Content-Length:")]
+        self.assertEqual(len(ct), 1)
+        self.assertEqual(ct[0].strip(), "Content-Length: 1061")
+
+        data = json.loads("\n".join(body))
+        self.assertEqual(data['@id'], "ark:/88434/mds2-2106/pdr:v/1.4.0/cmps/Readme.txt")
+        self.assertEqual(data['downloadURL'],
+                         "https://data.nist.gov/od/ds/ark:/88434/mds2-2106/_v/1.4.0/Readme.txt")
+        self.assertEqual(data['isPartOf'], "ark:/88434/mds2-2106/pdr:v/1.4.0")
+        self.assertEqual(data['version'], "1.4.0")
+        self.assertIn('@context', data)
+
+        self.resp = []
+        req = {
+            'REQUEST_METHOD': "GET",
+            'PATH_INFO': "ark:/88434/mds2-2106/pdr:v/1.4.0/pdr:f/Readme.txt",
+            'QUERY_STRING': "format=native"
+        }
+        hdlr = self.gethandler(req['PATH_INFO'], req)
+        body = self.tostr( hdlr.handle() )
+
+        self.assertEqual(self.resp[0][:4], "302 ")
+        hdr = [h for h in self.resp if h.startswith("Location: ")]
+        self.assertEqual(hdr[0],
+                         "Location: https://data.nist.gov/od/ds/ark:/88434/mds2-2106/_v/1.4.0/Readme.txt")
+
+
+        
+
+        
+
+
+
+
+
+
+if __name__ == '__main__':
+    test.main()
+
+


### PR DESCRIPTION
We now have one production NERDm record that, with over 11k files, is too big to fit as a single document into our MongoDB collections.  This PR gets around this by allowing large records to reside on disk.  This capability is handled via the resolver service (which in turn relies on `MetadataClient` class from the `nistoar.pdr.describe` module): the service first looks to see if there is a version on disk it can serve up before falling back on the RMM.  This solution would not likely perform well if there are many files on disk.

To test this, please see oar-docker PR#XX.
