### PR TITLE
DAP Publishing: fix DAP API issues

### DIFF
--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -781,6 +781,11 @@ class DAPService(ProjectService):
             for fmd in files:
                 nerd.files.set_file_at(fmd)
 
+        except InvalidUpdate as ex:
+            self.log.error("Invalid update to NERDm data not saved: %s: %s", prec.id, str(ex))
+            if ex.errors:
+                self.log.error("Errors include:\n  "+("\n  ".join([str(e) for e in ex.errors])))
+            raise
         except Exception as ex:
             provact.message = "Failed to save NERDm data update due to internal error"
             self.log.error("Failed to save NERDm metadata: "+str(ex))
@@ -1020,6 +1025,11 @@ class DAPService(ProjectService):
 
         except PartNotAccessible:
             # client request error; don't record action
+            raise
+        except InvalidUpdate as ex:
+            self.log.error("Invalid update to NERDm data not saved: %s: %s", prec.id, str(ex))
+            if ex.errors:
+                self.log.error("Errors include:\n  "+("\n  ".join([str(e) for e in ex.errors])))
             raise
         except Exception as ex:
             self.log.error("Failed to save update to NERDm data, %s: %s", prec.id, str(ex))

--- a/python/tests/nistoar/midas/dap/service/test_mds3.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3.py
@@ -928,6 +928,15 @@ class TestMDS3DAPService(test.TestCase):
         self.assertNotIn("references", nerd)
         self.assertEqual(len(nerd["components"]), 2)
 
+    def test_set_landingpage(self):
+        self.create_service()
+        prec = self.svc.create_record("goob")
+        id = prec.id
+        nerd = self.svc._store.open(id)
+
+        self.svc.replace_data(id, "https://example.com/", part="landingPage")
+        res = nerd.get_res_data()
+        self.assertEqual(res.get('landingPage'), "https://example.com/")
         
                 
         

--- a/python/tests/nistoar/midas/dbio/test_project.py
+++ b/python/tests/nistoar/midas/dbio/test_project.py
@@ -230,6 +230,32 @@ class TestProjectService(test.TestCase):
 
         self.assertEqual(len(self.project.dbcli._db.get(base.PROV_ACT_LOG, {}).get(prec.id,[])), 6)
 
+    def test_clear_data(self):
+        self.create_service()
+        prec = self.project.create_record("goob")
+        self.assertEqual(prec.data, {})
+        
+        data = self.project.update_data(prec.id, {"color": "red", "pos": {"x": 23, "y": 12, "grid": "A"}})
+        self.assertEqual(data, {"color": "red", "pos": {"x": 23, "y": 12, "grid": "A"}})
+        prec = self.project.get_record(prec.id)
+        self.assertEqual(prec.data, {"color": "red", "pos": {"x": 23, "y": 12, "grid": "A"}})
+
+        self.assertIs(self.project.clear_data(prec.id, "color"), True)
+        prec = self.project.get_record(prec.id)
+        self.assertEqual(prec.data, {"pos": {"x": 23, "y": 12, "grid": "A"}})
+
+        self.assertIs(self.project.clear_data(prec.id, "color"), False)
+        self.assertIs(self.project.clear_data(prec.id, "gurn/goob/gomer"), False)
+
+        self.assertIs(self.project.clear_data(prec.id, "pos/y"), True)
+        prec = self.project.get_record(prec.id)
+        self.assertEqual(prec.data, {"pos": {"x": 23, "grid": "A"}})
+
+        self.assertIs(self.project.clear_data(prec.id), True)
+        prec = self.project.get_record(prec.id)
+        self.assertEqual(prec.data, {})
+        
+
     def test_finalize(self):
         self.create_service()
         prec = self.project.create_record("goob")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,8 +30,6 @@ echo Installing python libraries into $PY_LIBDIR...
 
 $oarmd_pkg/scripts/install_extras.sh --install-dir=$INSTALL_DIR
 mkdir -p $INSTALL_DIR/etc/midas/schemas
-echo $execdir/loosen_nerdm.py $INSTALL_DIR/etc/schemas $INSTALL_DIR/etc/midas/schemas
-$execdir/loosen_nerdm.py $INSTALL_DIR/etc/schemas $INSTALL_DIR/etc/midas/schemas
 
 mkdir -p $INSTALL_DIR/var/logs
 echo cp -r $SOURCE_DIR/etc $INSTALL_DIR

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,6 +29,9 @@ echo Installing python libraries into $PY_LIBDIR...
 # None at this time
 
 $oarmd_pkg/scripts/install_extras.sh --install-dir=$INSTALL_DIR
+mkdir -p $INSTALL_DIR/etc/midas/schemas
+echo $execdir/loosen_nerdm.py $INSTALL_DIR/etc/schemas $INSTALL_DIR/etc/midas/schemas
+$execdir/loosen_nerdm.py $INSTALL_DIR/etc/schemas $INSTALL_DIR/etc/midas/schemas
 
 mkdir -p $INSTALL_DIR/var/logs
 echo cp -r $SOURCE_DIR/etc $INSTALL_DIR

--- a/scripts/loosen_nerdm.py
+++ b/scripts/loosen_nerdm.py
@@ -49,17 +49,17 @@ directives_by_file = {
     }
 }
 
-try:
-    import nistoar.nerdm.utils as nerdm_utils
-except ImportError:
-    sys.path.insert(0, find_nistoar_code())
-    import nistoar.nerdm.utils as nerdm_utils
-
 def find_nistoar_code():
     execdir = Path(__file__).resolve().parents[0]
     basedir = execdir.parents[0]
     mdpydir = basedir / "metadata" / "python"
     return mdpydir
+
+try:
+    import nistoar.nerdm.utils as nerdm_utils
+except ImportError:
+    sys.path.insert(0, str(find_nistoar_code()))
+    import nistoar.nerdm.utils as nerdm_utils
 
 def loosen_schema(schema: Mapping, directives: Mapping, opts=None):
     """

--- a/scripts/loosen_nerdm.py
+++ b/scripts/loosen_nerdm.py
@@ -1,0 +1,172 @@
+#! /usr/bin/env python3
+#
+import os, sys, json, argparse, traceback, re
+from pathlib import Path
+from collections import OrderedDict
+from collections.abc import Mapping
+
+description="""create copies of NERDm schemas with loosened requirements appropriate for the 
+metadata drafting process (i.e. within MIDAS)"""
+epilog=""
+def_progname = "loosen_nerdm"
+
+def define_options(progname, parser=None):
+    """
+    define command-line arguments
+    """
+    if not parser:
+        parser = argparse.ArgumentParser(progname, None, description, epilog)
+
+    parser.add_argument("srcdir", metavar="SRCDIR", type=str, 
+                        help="the directory containing the NERDm schemas")
+    parser.add_argument("destdir", metavar="DESTDIR", type=str, 
+                        help="the directory write loosened schemas to")
+    parser.add_argument("-D", "--no-dedocument", dest="dedoc", action="store_false", default=True,
+                        help="do not remove documentation from source schemas")
+    parser.add_argument("-J", "--assume-post2020", dest="post2020", action="store_true", default=False,
+                        help="assume schemas are compliant with a post-2020 JSON Schema specification "+
+                             "(and uses $defs)")
+    parser.add_argument("-m", "--make-dest-dir", dest="mkdest", action="store_true", default=False,
+                        help="create the destination directory if it does not exist")
+
+    return parser
+
+def set_options(progname, args):
+    """
+    define and parse the command-line options
+    """
+    return define_options(progname).parse_args(args)
+
+directives_by_file = {
+    "nerdm-schema.json": {
+        "derequire": [ "Resource", "Organization" ]
+    },
+    "nerdm-pub-schema.json": {
+        "derequire": [ "PublicDataResource", "Person" ]
+    }
+}
+
+try:
+    import nistoar.nerdm.utils as utils
+except ImportError:
+    sys.path.insert(0, find_nistoar_code())
+    import nistoar.nerdm.utils as utils
+
+def find_nistoar_code():
+    execdir = Path(__file__).resolve().parents[0]
+    basedir = execdir.parents[0]
+    mdpydir = basedir / "metadata" / "python"
+    return mdpydir
+
+def loosen_schema(schema: Mapping, directives: Mapping, opts=None):
+    """
+    apply the given loosening directive to the given JSON Schema.  The directives is a 
+    dictionary describes what to do with the following properties (the directives) supported:
+
+    ``derequire``
+         a list of type definitions within the schema from which the required property 
+         should be removed (via :py:func:`~nistoar.nerdm.utils.unrequire_props_in`).  Each
+         type name listed will be assumed to be an item under the "definitions" node in the 
+         schema this directive is applied to.
+    ``dedocument``
+         a boolean indicating whether the documentation annotations should be removed from 
+         the schema.  If not set, the default is determined by opts.dedoc if opts is given or
+         True, otherwise.  
+
+    :param dict schema:      the schema document as a JSON Schema schema dictionary
+    :param dict directives:  the dictionary of directives to apply
+    :param opt:              an options object (containing scripts command-line options)
+    """
+    dedoc = directives.get("dedocument", True)
+    if opts and not opts.dedoc:
+        dedoc = False
+    if dedoc:
+        utils.declutter_schema(schema)
+
+    p2020 = False
+    if opts:
+        p2020 = opts.post2020
+    deftag = "$defs" if p2020 else "definitions"
+
+    dereqtps = [ deftag+'.'+t for t in directives.get("derequire", []) ]
+    utils.unrequire_props_in(schema, dereqtps, p2020)
+
+def process_nerdm_schemas(srcdir, destdir, opts=None):
+    """
+    process all NERDm schemas (core and extensions) found in the source directory
+    and write the modified schemas to the output directory
+    """
+    if not os.path.isdir(srcdir):
+        raise RuntimeException(f"{srcdir}: schema source directory does not exist as directory")
+    
+    if not os.path.exists(destdir):
+        if opts and opts.mkdest:
+            os.makedirs(destdir)
+        else:
+            raise FileNotFoundError(destdir)
+    if not os.path.isdir(srcdir):
+        raise RuntimeException(f"{destdir}: schema destination is not a directory")
+
+    nerdfilere = re.compile(r"^nerdm-([a-zA-Z][^\-]*\-)?schema.json$")
+    schfiles = [f for f in os.listdir(srcdir) if nerdfilere.match(f)]
+
+    failed={}
+    for f in schfiles:
+        try:
+            with open(os.path.join(srcdir, f)) as fd:
+                schema = json.load(fd, object_pairs_hook=OrderedDict)
+        except IOError as ex:
+            failed[f] = f"Trouble reading schema file: {str(ex)}"
+            continue
+
+        directives = directives_by_file.get(f, {})
+        try:
+            loosen_schema(schema, directives, opts)
+        except Exception as ex:
+            failed[f] = f"Trouble processing schema file: {str(ex)}"
+            continue
+
+        with open(os.path.join(destdir, f), 'w') as fd:
+            json.dump(schema, fd, indent=2)
+            fd.write("\n")
+
+    return failed
+
+def main(progname=None, args=[]):
+    global def_progname;
+    if not progname:
+        progname = def_progname
+    else:
+        progname = os.path.basename(progname)
+        if progname.endswith(".py"):
+            progname = progname[:-1*len(".py")]
+
+    opts = set_options(progname, args)
+
+    failed = process_nerdm_schemas(opts.srcdir, opts.destdir, opts)  # may raise exceptions
+    if failed:
+        print(f"{progname}: WARNING: failed to process the following schemas:", file=sys.stderr)
+        for f, err in failed:
+            print(f"  {f}: {err}", file=sys.stderr)
+
+        return 3
+
+    return 0
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[0], sys.argv[1:]))
+    except RuntimeError as ex:
+        print(f"{progname}: {str(ex)}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as ex:
+        print("Unexpected error: "+str(ex), file=sys.stderr)
+        traceback.print_tb(sys.exc_info()[2])
+        sys.exit(4)
+
+
+        
+        
+    
+            
+            

--- a/scripts/loosen_nerdm.py
+++ b/scripts/loosen_nerdm.py
@@ -43,14 +43,17 @@ directives_by_file = {
     },
     "nerdm-pub-schema.json": {
         "derequire": [ "PublicDataResource", "Person" ]
+    },
+    "nerdm-rls-schema.json": {
+        "derequire": [ "ReleasedResource" ]
     }
 }
 
 try:
-    import nistoar.nerdm.utils as utils
+    import nistoar.nerdm.utils as nerdm_utils
 except ImportError:
     sys.path.insert(0, find_nistoar_code())
-    import nistoar.nerdm.utils as utils
+    import nistoar.nerdm.utils as nerdm_utils
 
 def find_nistoar_code():
     execdir = Path(__file__).resolve().parents[0]
@@ -77,20 +80,13 @@ def loosen_schema(schema: Mapping, directives: Mapping, opts=None):
     :param dict directives:  the dictionary of directives to apply
     :param opt:              an options object (containing scripts command-line options)
     """
-    dedoc = directives.get("dedocument", True)
-    if opts and not opts.dedoc:
-        dedoc = False
-    if dedoc:
-        utils.declutter_schema(schema)
-
-    p2020 = False
     if opts:
-        p2020 = opts.post2020
-    deftag = "$defs" if p2020 else "definitions"
+        if not opts.dedoc:
+            directives["dedocument"] = False
+        directives["post2020"] = opts.post2020
 
-    dereqtps = [ deftag+'.'+t for t in directives.get("derequire", []) ]
-    utils.unrequire_props_in(schema, dereqtps, p2020)
-
+    nerdm_utils.loosen_schema(schema, directives)
+    
 def process_nerdm_schemas(srcdir, destdir, opts=None):
     """
     process all NERDm schemas (core and extensions) found in the source directory

--- a/scripts/tests/test_loosen_nerdm.py
+++ b/scripts/tests/test_loosen_nerdm.py
@@ -1,0 +1,185 @@
+#! /usr/bin/env python3
+#
+import sys, os, csv, json, re
+import importlib.util as imputil
+import unittest as test
+from pathlib import Path
+from collections import OrderedDict
+
+from nistoar.testing import *
+from nistoar.base.config import hget
+
+testdir = Path(__file__).resolve().parents[0]
+scrpdir = testdir.parents[0]
+basedir = scrpdir.parents[0]
+nerdmdir = basedir / "metadata" / "model"
+
+scriptfile = str(scrpdir / "loosen_nerdm.py")
+
+def import_file(path, name=None):
+    if not name:
+        name = os.path.splitext(os.path.basename(path))[0]
+    import importlib.util as imputil
+    spec = imputil.spec_from_file_location(name, path)
+    out = imputil.module_from_spec(spec)
+    sys.modules["loosen"] = out
+    spec.loader.exec_module(out)
+    return out
+
+loosen = None  # set at end of this file
+
+def setUpModule():
+    ensure_tmpdir()
+
+def tearDownModule():
+    rmtmpdir()
+
+
+class TestLoosenNerdm(test.TestCase):
+
+    def test_import(self):
+        self.assertIsNotNone(loosen)
+        self.assertTrue(hasattr(loosen, 'main'))
+        self.assertIsNotNone(loosen.directives_by_file)
+
+    def setUp(self):
+        self.tf = Tempfiles()
+        self.destdir = self.tf.mkdir("loosen_nerdm")
+
+    def tearDown(self):
+        self.tf.clean()
+
+    def test_set_options(self):
+        try:
+            opts = loosen.set_options(loosen.def_progname, ["-D", "goob", "gurn"])
+            self.assertFalse(opts.dedoc)
+            self.assertFalse(opts.post2020)
+            self.assertEqual(opts.srcdir, "goob")
+            self.assertEqual(opts.destdir, "gurn")
+
+            opts = loosen.set_options(loosen.def_progname, ["-J", "goob", "gurn"])
+            self.assertTrue(opts.dedoc)
+            self.assertTrue(opts.post2020)
+            self.assertEqual(opts.srcdir, "goob")
+            self.assertEqual(opts.destdir, "gurn")
+
+            opts = loosen.set_options(loosen.def_progname, ["harry", "david"])
+            self.assertTrue(opts.dedoc)
+            self.assertFalse(opts.post2020)
+            self.assertEqual(opts.srcdir, "harry")
+            self.assertEqual(opts.destdir, "david")
+        except SystemExit as ex:
+            self.fail("error processing args")
+        
+    def test_find_nistoar_code(self):
+        self.assertEqual(loosen.find_nistoar_code().parts[-2:], ("metadata", "python"))
+
+    def test_loosen_schema(self):
+        with open(nerdmdir/"nerdm-schema.json") as fd:
+            schema = json.load(fd, object_pairs_hook=OrderedDict)
+
+        self.assertTrue(hget(schema, "title"))
+        self.assertTrue(hget(schema, "description"))
+        self.assertTrue(hget(schema, "definitions.Resource.required"))
+        self.assertTrue(hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(hget(schema, "definitions.Organization.description"))
+
+        loosen.loosen_schema(schema, {"derequire": ["Resource"], "dedocument": True})
+        
+        self.assertTrue(not hget(schema, "title"))
+        self.assertTrue(not hget(schema, "description"))
+        self.assertTrue(not hget(schema, "definitions.Resource.required"))
+        self.assertTrue(not hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(not hget(schema, "definitions.Organization.description"))
+
+    def test_loosen_schema_no_dedoc(self):
+        with open(nerdmdir/"nerdm-schema.json") as fd:
+            schema = json.load(fd, object_pairs_hook=OrderedDict)
+
+        self.assertTrue(hget(schema, "title"))
+        self.assertTrue(hget(schema, "description"))
+        self.assertTrue(hget(schema, "definitions.Resource.required"))
+        self.assertTrue(hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(hget(schema, "definitions.Organization.description"))
+
+        loosen.loosen_schema(schema, {"derequire": ["Resource"], "dedocument": False})
+        
+        self.assertTrue(hget(schema, "title"))
+        self.assertTrue(hget(schema, "description"))
+        self.assertTrue(not hget(schema, "definitions.Resource.required"))
+        self.assertTrue(hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(hget(schema, "definitions.Organization.description"))
+
+    def test_loosen_schema_with_opts(self):
+        with open(nerdmdir/"nerdm-schema.json") as fd:
+            schema = json.load(fd, object_pairs_hook=OrderedDict)
+        opts = loosen.set_options(loosen.def_progname, ["goob", "gurn"])
+
+        self.assertTrue(hget(schema, "title"))
+        self.assertTrue(hget(schema, "description"))
+        self.assertTrue(hget(schema, "definitions.Resource.required"))
+        self.assertTrue(hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(hget(schema, "definitions.Organization.description"))
+
+        loosen.loosen_schema(schema, {"derequire": ["Resource"]}, opts)
+        
+        self.assertTrue(not hget(schema, "title"))
+        self.assertTrue(not hget(schema, "description"))
+        self.assertTrue(not hget(schema, "definitions.Resource.required"))
+        self.assertTrue(not hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(not hget(schema, "definitions.Organization.description"))
+
+    def test_loosen_schema_with_opts_D(self):
+        with open(nerdmdir/"nerdm-schema.json") as fd:
+            schema = json.load(fd, object_pairs_hook=OrderedDict)
+        opts = loosen.set_options(loosen.def_progname, ["-D", "goob", "gurn"])
+
+        self.assertTrue(hget(schema, "title"))
+        self.assertTrue(hget(schema, "description"))
+        self.assertTrue(hget(schema, "definitions.Resource.required"))
+        self.assertTrue(hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(hget(schema, "definitions.Organization.description"))
+
+        loosen.loosen_schema(schema, {"derequire": ["Resource"]}, opts)
+        
+        self.assertTrue(hget(schema, "title"))
+        self.assertTrue(hget(schema, "description"))
+        self.assertTrue(not hget(schema, "definitions.Resource.required"))
+        self.assertTrue(hget(schema, "definitions.Resource.description"))
+        self.assertTrue(hget(schema, "definitions.Organization.required"))
+        self.assertTrue(hget(schema, "definitions.Organization.description"))
+        
+    def test_process_nerdm_schemas(self):
+        schfre = re.compile(r"^nerdm-([a-zA-Z][^\-]*\-)?schema.json$")
+        srcfiles = [f for f in os.listdir(nerdmdir) if schfre.match(f)]
+        self.assertGreater(len(srcfiles), 6)
+
+        destfiles = [f for f in os.listdir(self.destdir) if not f.startswith('.')]
+        self.assertEqual(destfiles, [])
+        self.assertEqual(loosen.process_nerdm_schemas(nerdmdir, self.destdir), {})
+
+        destfiles = [f for f in os.listdir(self.destdir) if not f.startswith('.')]
+        self.assertIn("nerdm-schema.json", destfiles)
+        self.assertIn("nerdm-pub-schema.json", destfiles)
+        for schfile in srcfiles:
+            self.assertIn(schfile, destfiles)
+        self.assertEqual(len(destfiles), len(srcfiles))
+
+
+
+    
+
+        
+        
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        scriptfile = sys.argv[1]
+    loosen = import_file(scriptfile)
+    test.main()


### PR DESCRIPTION
This PR addresses the API problems enumerated in task ##, which point errors that occur when trying to edit or delete certain parts of a NERDm record.  A common problem affecting several of the items was that an incorrect version of ejsonschema was being installed in oar-docker's dbio container (see oar-docker PR ##).  Beyond that, this PR makes the following changes:
- the code for creating (on-the-fly) more lenient schemas for checking the result of update requests was replaced with an implementation that will be much simpler to expand.  Furthermore, this new implementation removes documentation tags from the lenient schemas which should make validation error messages more compact.  Much of this implementation is pulled in from the oar-metadata submodule (see oar-metadata PR ##).  
- support for clearing parts of a NERDm record is added/fixed in the web interface

To test, check out the test/dbio-missing-api branch of oar-docker, build and run it, and then test that the DAP can properly update data mentioned in ##, including the home page and references.  
