### PR TITLE
Make more data fields searchable: theme, keyword, and responsibleOrganization

### DIFF
--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -365,7 +365,7 @@ class DAPService(ProjectService):
                 m = re.search(r'/v(\d+\.\d+(\.\d+)*)#?$', schemaid)
                 if schemaid.startswith(NERDM_SCH_ID_BASE) and m:
                     ver = m.group(1).split('.')
-                    for v in range(len(ver)):
+                    for i in range(len(ver)):
                         if i >= len(self._minnerdmver):
                             break;
                         if ver[i] < self._minnerdmver[1]:
@@ -800,6 +800,13 @@ class DAPService(ProjectService):
             out["contactPoint"] = resmd["contactPoint"]
         if 'landingPage' in resmd:
             out["landingPage"] = resmd["landingPage"]
+        out["keyword"] = resmd.get("keyword", [])
+        out["theme"] = list(set(resmd.get("theme", []) + [t.get('tag') for t in resmd.get('topic', [])]))
+        if resmd.get('responsibleOrganization'):
+            out['responsibleOrganization'] = list(set(
+                [org.title for org in resmd['responsibleOrganization']] + \
+                reduce(lambda x, y: x+y, [org.subunit for org in resmd['responsibleOrganization']], [])
+            ))
         out["author_count"] = nerd.authors.count
         out["file_count"] = nerd.files.count
         out["nonfile_count"] = nerd.nonfiles.count

--- a/python/tests/nistoar/midas/dap/service/test_mds3_app.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3_app.py
@@ -189,7 +189,7 @@ class TestMDS3DAPApp(test.TestCase):
         self.assertIs(resp['meta']["creatorisContact"], False)
         self.assertEqual(resp['data']['@id'], 'ark:/88434/mds3-0002')
         self.assertEqual(resp['data']['doi'], 'doi:10.88888/mds3-0002')
-        self.assertNotIn('keyword', resp['data'])    # because ['data'] is just a summary
+        self.assertNotIn('authors', resp['data'])    # because ['data'] is just a summary
         self.assertIn('contactPoint', resp['data'])  # this is included in ['data'] summary
 
         self.resp = []
@@ -248,7 +248,7 @@ class TestMDS3DAPApp(test.TestCase):
         self.assertIs(resp['meta']["creatorisContact"], False)
         self.assertEqual(resp['data']['@id'], 'ark:/88434/mds3-0001')
         self.assertEqual(resp['data']['doi'], 'doi:10.88888/mds3-0001')
-        self.assertNotIn('keyword', resp['data'])    # because ['data'] is just a summary
+        self.assertNotIn('authors', resp['data'])    # because ['data'] is just a summary
         self.assertIn('contactPoint', resp['data'])  # this is included in ['data'] summary
         
         self.resp = []

--- a/python/tests/nistoar/midas/dap/service/test_mds3_app_wfm.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3_app_wfm.py
@@ -232,7 +232,7 @@ class TestMDS3DAPApp(test.TestCase):
         self.assertIs(resp['meta']["creatorisContact"], False)
         self.assertEqual(resp['data']['@id'], 'ark:/88434/mds3-0002')
         self.assertEqual(resp['data']['doi'], 'doi:10.88888/mds3-0002')
-        self.assertNotIn('keyword', resp['data'])    # because ['data'] is just a summary
+        self.assertNotIn('authors', resp['data'])    # because ['data'] is just a summary
         self.assertIn('contactPoint', resp['data'])  # this is included in ['data'] summary
 
         self.resp = []
@@ -298,7 +298,7 @@ class TestMDS3DAPApp(test.TestCase):
         self.assertIs(resp['meta']["creatorisContact"], False)
         self.assertEqual(resp['data']['@id'], 'ark:/88434/mds3-0001')
         self.assertEqual(resp['data']['doi'], 'doi:10.88888/mds3-0001')
-        self.assertNotIn('keyword', resp['data'])    # because ['data'] is just a summary
+        self.assertNotIn('authors', resp['data'])    # because ['data'] is just a summary
         self.assertIn('contactPoint', resp['data'])  # this is included in ['data'] summary
         
         self.resp = []

--- a/python/tests/nistoar/midas/dbio/data/asc_keyandtheme.json
+++ b/python/tests/nistoar/midas/dbio/data/asc_keyandtheme.json
@@ -1,0 +1,10 @@
+{
+    "$and": [
+        {
+            "data.keyword": { "$in": ["Ray"] }
+          },
+        {
+            "data.theme": { "$in": ["Gretchen"] }
+        }
+    ]
+}

--- a/python/tests/nistoar/midas/dbio/test_inmem.py
+++ b/python/tests/nistoar/midas/dbio/test_inmem.py
@@ -286,13 +286,18 @@ class TestInMemoryDBClient(test.TestCase):
 
         id = "pdr0:0003"
         rec = base.ProjectRecord(
-            base.DMP_PROJECTS, {"id": id, "name": "test3", "status": {
+            base.DMP_PROJECTS, {"id": id, "name": "test3","title":"Gretchen", "status": {
                 "created": 1689021185.5037804,
                 "state": "edit",
                 "action": "create",
                 "since": 1689021185.5038593,
                 "modified": 1689021185.5050585,
                 "message": "draft created"
+            },
+            "data": {
+                "keyword": ["Ray", "Bob"],
+                "theme": ["Gretchen", "Deo"]
+
             }}, self.cli)
         self.cli._db[base.DMP_PROJECTS][id] = rec.to_dict()
 
@@ -316,7 +321,10 @@ class TestInMemoryDBClient(test.TestCase):
         recs = list(self.cli.adv_select_records(constraint_or))
         self.assertEqual(len(recs), 2)
         self.assertEqual(recs[0].id, "pdr0:0006")
+        print(recs[1].data["keyword"])
         self.assertEqual(recs[1].id, "pdr0:0003")
+        self.assertEqual(recs[1].data["keyword"][0], "Ray")
+        self.assertEqual(recs[1].data["theme"][0], "Gretchen")
 
         recs = list(self.cli.adv_select_records(constraint_and))
         self.assertEqual(len(recs), 1)

--- a/python/tests/nistoar/midas/dbio/test_inmem.py
+++ b/python/tests/nistoar/midas/dbio/test_inmem.py
@@ -321,7 +321,6 @@ class TestInMemoryDBClient(test.TestCase):
         recs = list(self.cli.adv_select_records(constraint_or))
         self.assertEqual(len(recs), 2)
         self.assertEqual(recs[0].id, "pdr0:0006")
-        print(recs[1].data["keyword"])
         self.assertEqual(recs[1].id, "pdr0:0003")
         self.assertEqual(recs[1].data["keyword"][0], "Ray")
         self.assertEqual(recs[1].data["theme"][0], "Gretchen")

--- a/python/tests/nistoar/midas/dbio/test_mongo.py
+++ b/python/tests/nistoar/midas/dbio/test_mongo.py
@@ -21,6 +21,7 @@ asc_or    = datadir / 'asc_or.json'
 dmp_path  = datadir / 'dmp.json'
 asc_dates = datadir / 'asc_dates.json'
 asc_text  = datadir / 'asc_text.json'
+asc_keyandtheme = datadir / 'asc_keyandtheme.json'
 
 with open(asc_or, 'r') as file:
     constraint_or = json.load(file)
@@ -39,6 +40,9 @@ with open(asc_dates, 'r') as file:
 
 with open(asc_text, 'r') as file:
     constraint_text = json.load(file)
+
+with open(asc_keyandtheme, 'r') as file:
+    constraint_keyandtheme = json.load(file)
 
 @test.skipIf(not os.environ.get('MONGO_TESTDB_URL'), "test mongodb not available")
 class TestInMemoryDBClientFactory(test.TestCase):
@@ -334,7 +338,13 @@ class TestMongoDBClient(test.TestCase):
                 "since": 1689021185.5038593,
                 "modified": 1689021185.5050585,
                 "message": "draft created"
-            }}, self.cli)
+            },
+            "data": {
+                "keyword": ["Chemistry", "Bob"],
+                "theme": ["Physics", "Deo"]
+
+            }
+            }, self.cli)
         self.cli.native[base.DMP_PROJECTS].insert_one(rec.to_dict())
 
         id = "pdr0:0006"
@@ -346,7 +356,13 @@ class TestMongoDBClient(test.TestCase):
                 "since": 1689021185.5038593,
                 "modified": 1689021180.5050585,
                 "message": "draft created"
-            }}, self.cli)
+            },
+            "data": {
+                "keyword": ["Ray", "Bob"],
+                "theme": ["Gretchen", "Deo"]
+
+            }
+            }, self.cli)
         self.cli.native[base.DMP_PROJECTS].insert_one(rec.to_dict())
 
         id = "pdr0:0003"
@@ -414,6 +430,11 @@ class TestMongoDBClient(test.TestCase):
         self.assertEqual(recs[0].id, "pdr0:0006")
         self.assertEqual(recs[1].id, "pdr0:0002")
         self.assertEqual(recs[2].id, "pdr0:0008")
+
+        recs = list(self.cli.adv_select_records(constraint_keyandtheme, base.ACLs.READ))
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0].id, "pdr0:0006")
+
         
 
     def test_action_log_io(self):


### PR DESCRIPTION
In DBIO DAP records, the `data` property only contains summary information from the full NERDm record being edited by the user.  To be searchable via the DBIO search interface, NERDm properties must be explicitly included in the `data` property object.  This PR adds the new properties to this summary:  `keyword`, `theme` (which includes terms from both the NERDm properties `theme` and `topic.tag`), and `responsibleOrganization`.  These have been added to facilitate the advanced search interface provided by the front-end portal.  
