### PR TITLE
 keyword lowercase and plural + test for multiple keywords research

### DIFF
--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -800,7 +800,7 @@ class DAPService(ProjectService):
             out["contactPoint"] = resmd["contactPoint"]
         if 'landingPage' in resmd:
             out["landingPage"] = resmd["landingPage"]
-        out["keyword"] = resmd.get("keyword", [])
+        out["keywords"] = resmd.get("keywords", [])
         out["theme"] = list(set(resmd.get("theme", []) + [t.get('tag') for t in resmd.get('topic', [])]))
         if resmd.get('responsibleOrganization'):
             out['responsibleOrganization'] = list(set(

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -800,7 +800,7 @@ class DAPService(ProjectService):
             out["contactPoint"] = resmd["contactPoint"]
         if 'landingPage' in resmd:
             out["landingPage"] = resmd["landingPage"]
-        out["keywords"] = resmd.get("keywords", [])
+        out["keywords"] = resmd.get("keyword", [])
         out["theme"] = list(set(resmd.get("theme", []) + [t.get('tag') for t in resmd.get('topic', [])]))
         if resmd.get('responsibleOrganization'):
             out['responsibleOrganization'] = list(set(

--- a/python/tests/nistoar/midas/dap/service/test_mds3_app.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3_app.py
@@ -248,6 +248,7 @@ class TestMDS3DAPApp(test.TestCase):
         self.assertIs(resp['meta']["creatorisContact"], False)
         self.assertEqual(resp['data']['@id'], 'ark:/88434/mds3-0001')
         self.assertEqual(resp['data']['doi'], 'doi:10.88888/mds3-0001')
+        self.assertEqual(resp['data']['keywords'], ['testing'])
         self.assertNotIn('authors', resp['data'])    # because ['data'] is just a summary
         self.assertIn('contactPoint', resp['data'])  # this is included in ['data'] summary
         
@@ -273,6 +274,7 @@ class TestMDS3DAPApp(test.TestCase):
                          [ "nrdp:PublicDataResource", "dcat:Resource" ])
         self.assertIn('_schema', resp)
         self.assertIn('_extensionSchemas', resp)
+        self.assertEqual(resp['keyword'], ['testing'])
         self.assertNotIn('components', resp)
         self.assertNotIn('authors', resp)
         self.assertNotIn('description', resp)

--- a/python/tests/nistoar/midas/dbio/data/asc_keyandtheme.json
+++ b/python/tests/nistoar/midas/dbio/data/asc_keyandtheme.json
@@ -1,7 +1,7 @@
 {
     "$and": [
         {
-            "data.keyword": { "$in": ["Ray"] }
+            "data.keywords": { "$in": ["Ray"] }
           },
         {
             "data.theme": { "$in": ["Gretchen"] }

--- a/python/tests/nistoar/midas/dbio/data/asc_orkeywords.json
+++ b/python/tests/nistoar/midas/dbio/data/asc_orkeywords.json
@@ -1,0 +1,15 @@
+{
+    "$and": [
+        {
+            "$or": [
+                {
+                    "data.keywords": { "$in": ["Ray"] }
+                  },
+                  {
+                    "data.keywords": { "$in": ["Bob"] }
+                  }
+                
+            ]
+        }
+    ]
+}

--- a/python/tests/nistoar/midas/dbio/test_mongo.py
+++ b/python/tests/nistoar/midas/dbio/test_mongo.py
@@ -22,6 +22,7 @@ dmp_path  = datadir / 'dmp.json'
 asc_dates = datadir / 'asc_dates.json'
 asc_text  = datadir / 'asc_text.json'
 asc_keyandtheme = datadir / 'asc_keyandtheme.json'
+asc_orkeywords = datadir / 'asc_orkeywords.json'
 
 with open(asc_or, 'r') as file:
     constraint_or = json.load(file)
@@ -43,6 +44,9 @@ with open(asc_text, 'r') as file:
 
 with open(asc_keyandtheme, 'r') as file:
     constraint_keyandtheme = json.load(file)
+
+with open(asc_orkeywords, 'r') as file:
+    constraint_orkeywords = json.load(file)
 
 @test.skipIf(not os.environ.get('MONGO_TESTDB_URL'), "test mongodb not available")
 class TestInMemoryDBClientFactory(test.TestCase):
@@ -340,7 +344,7 @@ class TestMongoDBClient(test.TestCase):
                 "message": "draft created"
             },
             "data": {
-                "keyword": ["Chemistry", "Bob"],
+                "keywords": ["Chemistry", "Bob"],
                 "theme": ["Physics", "Deo"]
 
             }
@@ -358,7 +362,7 @@ class TestMongoDBClient(test.TestCase):
                 "message": "draft created"
             },
             "data": {
-                "keyword": ["Ray", "Bob"],
+                "keywords": ["Ray", "Bob"],
                 "theme": ["Gretchen", "Deo"]
 
             }
@@ -434,6 +438,11 @@ class TestMongoDBClient(test.TestCase):
         recs = list(self.cli.adv_select_records(constraint_keyandtheme, base.ACLs.READ))
         self.assertEqual(len(recs), 1)
         self.assertEqual(recs[0].id, "pdr0:0006")
+
+        recs = list(self.cli.adv_select_records(constraint_orkeywords, base.ACLs.READ))
+        self.assertEqual(len(recs), 2)
+        self.assertEqual(recs[0].id, "pdr0:0002")
+        self.assertEqual(recs[1].id, "pdr0:0006")
 
         
 


### PR DESCRIPTION
Searching across both DMPs and DAPs via the portal will be aided where there are common properties under the data field.  Currently, general keywords are held under different names between the two project types:  `keyWords` vs. `keyword`, respectively.  This PR proposes to change both to `keywords`.