### PR TITLE
Update fm client for new webdav authentication

### DIFF
--- a/python/nistoar/midas/dap/fm/apiclient.py
+++ b/python/nistoar/midas/dap/fm/apiclient.py
@@ -256,11 +256,11 @@ class FileManager:
             raise FileSpaceException("File manager server error: {resp.reason}")
         elif resp.status_code >= 400:
             msg = resp.reason
-            if '/json' in resp.headers.get("content-header"):
+            if '/json' in resp.headers.get("content-type"):
                 body = response.json()
                 if isinstance(body, Mapping) and 'message' in body:
-                    msg = body['message']
-            elif '/xml' in resp.headers.get("content-header"):
+                    msg = str(body['message'])
+            elif '/xml' in resp.headers.get("content-type"):
                 try:
                     body = etree.parse(resp.text).getroot()
                     msgel = body.find(".//{DAV:}message")
@@ -268,6 +268,8 @@ class FileManager:
                         msg = msgel.text
                 except Exception as ex:
                     msg += " (no parseable message in response body)"
+            else:
+                msg += " (detail not specified)"
             raise FileSpaceException(msg, resp.status_code)
 
         base = self.dav_base

--- a/python/nistoar/midas/dap/nerdstore/fmfs.py
+++ b/python/nistoar/midas/dap/nerdstore/fmfs.py
@@ -199,7 +199,7 @@ class FMFSFileComps(FSBasedFileComps):
             if not isinstance(resp, Mapping):
                 self._res.log.error("Unexpected response from scan request: "+
                                     "not a JSON object (is URL correct?)")
-                raise RemoteStorageException("%s: failed to trigger file scan")
+                raise RemoteStorageException(f"{self._res.id}: failed to trigger file scan")
 
             elif 'scan_id' not in resp:
                 self._res.log.error("Unexpected response from scan request; no scan_id included")
@@ -218,11 +218,11 @@ class FMFSFileComps(FSBasedFileComps):
             self._res.log.error("Unexected response from scan request: failed to parse as JSON (%s)",
                                 str(ex))
             self._res.log.warning("(Is the fm base URL correct?)")
-            raise RemoteStorageException("%s: Failed to trigger file scan (unexpected response format)") \
-                from ex
+            raise RemoteStorageException("%s: Failed to trigger file scan (unexpected response format)" %
+                                         self._res.id) from ex
 
         except Exception as ex:
-            raise RemoteStorageException("%s: failed to trigger file scan: %s", self._res.id, str(ex)) \
+            raise RemoteStorageException(f"{self._res.id}: failed to trigger file scan: {str(ex)}") \
                 from ex
             
         return self._get_file_scan()
@@ -241,11 +241,11 @@ class FMFSFileComps(FSBasedFileComps):
             self._res.log.error("Unexected response while retrieving scan: failed to parse as JSON (%s)",
                                 str(ex))
             self._res.log.warning("(Is the fm base URL correct?)")
-            raise RemoteStorageException("%s: Failed to trigger file scan (unexpected response format)") \
-                from ex
+            raise RemoteStorageException("%s: Failed to trigger file scan (unexpected response format)" %
+                                         self._res.id) from ex
 
         except Exception as ex:
-            raise RemoteStorageException("%s: failed to trigger file scan: %s", self._res.id, str(ex)) \
+            raise RemoteStorageException(f"{self._res.id}: failed to trigger file scan: {str(ex)}") \
                 from ex
 
         if 'contents' not in resp or not isinstance(resp['contents'], list):

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -406,8 +406,8 @@ class DAPService(ProjectService):
                     if prec.file_space.get('file_count', -2) < 0:
                         self.log.warning("Failed to initialize file listing from file manager")
                 except Exception as ex:
-                    self.log.error("Failed to initialize file listing: problem accessing file manager: %s",
-                                   str(ex))
+                    self.log.exception("Failed to initialize file listing: problem accessing file manager: %s",
+                                       str(ex))
             prec.data = self._summarize(nerd)
 
             if data:


### PR DESCRIPTION
This adapts the file manager client code to the new X.509-supporting version of the file manager.  Specifically, leverages X.509 certs for authenticating to the WebDAV interface to determine the URL for visiting the uploads directory via Nextcloud.  This fix is considered somewhat temporary until the app-layer is merged into this repo.  
