### PR TITLE
DBIO: Enable reassignment of ownership of records

### DIFF
--- a/docker/midasserver/midas-dmpdapnsd_conf.yml
+++ b/docker/midasserver/midas-dmpdapnsd_conf.yml
@@ -2,6 +2,9 @@ logfile: midas.log
 loglevel: DEBUG
 dbio:
    factory:  fsbased
+   people_service:
+     factory:  mongo
+     db_url: "mongodb://oarop:oarop@mongodb:27017/midas"
 about: 
    title: "MIDAS Authoring Services"
    describedBy: "http://localhost:9091/midas/docs"

--- a/docker/midasserver/midas-dmpdapnsd_conf.yml
+++ b/docker/midasserver/midas-dmpdapnsd_conf.yml
@@ -1,5 +1,7 @@
 logfile: midas.log
 loglevel: DEBUG
+loglevelsfor :
+   pymongo: INFO 
 dbio:
    factory:  fsbased
    people_service:

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -38,7 +38,7 @@ from nistoar.nerdm import constants as nerdconst, utils as nerdutils
 from nistoar.pdr import def_schema_dir, def_etc_dir, constants as const
 from nistoar.pdr.utils import build_mime_type_map, read_json
 from nistoar.pdr.utils.prov import Agent, Action
-from nistoar.nsd.client import NSDClient
+from nistoar.nsd import NSDServerError
 
 from . import validate
 from .. import nerdstore
@@ -238,7 +238,7 @@ class DAPService(ProjectService):
 
     def __init__(self, dbclient_factory: DBClientFactory, config: Mapping={}, who: Agent=None,
                  log: Logger=None, nerdstore: NERDResourceStorage=None, project_type=DAP_PROJECTS,
-                 minnerdmver=(0, 6), fmcli=None, nsdcli=None):
+                 minnerdmver=(0, 6), fmcli=None, nsdsvc=None):
         """
         create the service
         :param DBClientFactory dbclient_factory:  the factory to create the DBIO service client from
@@ -253,8 +253,6 @@ class DAPService(ProjectService):
                                    subclass constructors.
         :param FileManager fmcli:  The FileManager client to use; if None, one will be constructed 
                                    from the configuration.
-        :param NSDClient  nsdcli:  The NSD client to use to look up people and organizations; if None, 
-                                   one will be constructed from the configuration.
         """
         super(DAPService, self).__init__(project_type, dbclient_factory, config, who, log,
                                          _subsys="Digital Asset Publication Authoring System",
@@ -269,13 +267,6 @@ class DAPService(ProjectService):
         if not nerdstore:
             nerdstore = NERDResourceStorageFactory().open_storage(config.get("nerdstorage", {}), log)
         self._store = nerdstore
-
-        self._nsdcli = nsdcli
-        if not self._nsdcli:
-            if not self.cfg.get('nsd', {}).get('service_endpoint'):
-                self.log.warning("NSD service is not configured; name lookups are not possible")
-            else:
-                self._nsdcli = self._make_nsd_client(config['nsd'])
 
         self.cfg.setdefault('assign_doi', ASSIGN_DOI_REQUEST)
         if not self.cfg.get('doi_naan') and self.cfg.get('assign_doi') != ASSIGN_DOI_NEVER:
@@ -295,11 +286,6 @@ class DAPService(ProjectService):
 
     def _make_fm_client(self, fmcfg):
         return FileManager(fmcfg)
-
-    def _make_nsd_client(self, nsdcfg):
-        if not nsdcfg.get('service_endpoint'):
-            raise ConfigurationException("nsd config missing 'service_endpoint' parameter")
-        return NSDClient(nsdcfg['service_endpoint'])
 
     def _choose_mediatype(self, fext):
         defmt = 'application/octet-stream'
@@ -473,17 +459,16 @@ class DAPService(ProjectService):
             elif meta.get("contactName"):
                 out['contactPoint'] = self._moderate_contactPoint({"fn": meta["contactName"]}, doval=False)
 
-            ro = self.cfg.get('default_responsible_org', {})
-            if self._nsdcli and out.get('contactPoint', {}).get('hasEmail'):
+            ro = deepcopy(self.cfg.get('default_responsible_org', {}))
+            if self.dbcli.people_service and out.get('contactPoint', {}).get('hasEmail'):
+                ps = self.dbcli.people_service
                 try:
-                    conrec = self._nsdcli.select_people(email=out.get['contactPoint']['hasEmail'])
+                    conrec = ps.get_person_by_email(email=out['contactPoint']['hasEmail'])
                 except NSDServerError as ex:
                     self.log.warning("Unable to get org info on contact from NSD service: %s", str(ex))
                 except Exception as ex:
                     self.log.exception("Unexpected error while accessing NSD service: %s", str(ex))
                 else:
-                    if len(conrec) > 0:
-                        conrec = conrec[0]
                     if conrec:
                         ro['subunits'] = []
                         if not ro.get('title'):

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -599,7 +599,7 @@ class DAPService(ProjectService):
                 out = nerd.get_res_data()
                 if part in out:
                     out = out[part]
-                elif part in "description @type contactPoint title rights disclaimer".split():
+                elif part in "description @type contactPoint title rights disclaimer landingPage".split():
                     raise ObjectNotFound(prec.id, part, "%s property not set yet" % part)
                 else:
                     raise PartNotAccessible(prec.id, part, "Accessing %s not supported" % part)

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -513,6 +513,30 @@ class Group(ProtectedRecord):
         """
         return self._data['name']
 
+
+    @name.setter
+    def name(self, val):
+        self.rename(val)
+
+    def rename(self, newname):
+        """
+        assign the given name as the groups's mnemonic name.  If this record was pulled from 
+        the backend storage, then a check will be done to ensure that the name does not match 
+        that of any other group owned by the current user.  
+
+        :param str newname:  the new name to assign to the record
+        :raises NotAuthorized:  if the calling user is not authorized to changed the name; for 
+                                non-superusers, ADMIN permission is required to rename a record.
+        :raises AlreadyExists:  if the name has already been given to a record owned by the 
+                                current user.  
+        """
+        if not self.authorized(ACLs.ADMIN):
+            raise NotAuthorized(self._cli.user_id, "change name")
+        if self._cli and self._cli.name_exists(newname):
+            raise AlreadyExists(f"User {self_cli.user_id} has already defined a group with name={newname}")
+
+        self._data['name'] = newname
+
     def validate(self, errs=None, data=None) -> List[str]:
         """
         validate this record and return a list of error statements about its validity or an empty list
@@ -813,7 +837,7 @@ class ProjectRecord(ProtectedRecord):
                                 current user.  
         """
         if not self.authorized(ACLs.ADMIN):
-            raise NotAuthorized(self._cli.user_id, "change owner")
+            raise NotAuthorized(self._cli.user_id, "change name")
         if self._cli and self._cli.name_exists(newname):
             raise AlreadyExists(f"User {self_cli.user_id} has already defined a record with name={newname}")
 

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -25,11 +25,12 @@ from nistoar.pdr.utils.prov import Action
 from .. import MIDASException
 from .status import RecordStatus
 from nistoar.pdr.utils.prov import ANONYMOUS_USER
+from nistoar.nsd.service import PeopleService, create_people_service
 
 DAP_PROJECTS = "dap"
 DMP_PROJECTS = "dmp"
 GROUPS_COLL = "groups"
-PEOPLE_COLL = "people"
+PEOPLE_COLL = "people"     # this does not refer to the staff directory database
 DRAFT_PROJECTS = "draft"   # this name is deprecated
 PROV_ACT_LOG = "prov_action_log"
 
@@ -41,7 +42,8 @@ PUBLIC_GROUP = DEF_GROUPS_SHOULDER + ":public"    # all users are implicitly par
 ANONYMOUS = ANONYMOUS_USER
 
 __all__ = ["DBClient", "DBClientFactory", "ProjectRecord", "DBGroups", "Group", "ACLs", "PUBLIC_GROUP",
-           "ANONYMOUS", "DAP_PROJECTS", "DMP_PROJECTS", "ObjectNotFound", "NotAuthorized", "AlreadyExists"]
+           "ANONYMOUS", "DAP_PROJECTS", "DMP_PROJECTS", "ObjectNotFound", "NotAuthorized", "AlreadyExists",
+           "InvalidRecord", "InvalidUpdate" ]
 
 Permissions = Union[str, Sequence[str], AbstractSet[str]]
 CST = []
@@ -323,6 +325,35 @@ class ProtectedRecord(ABC):
              self._data['since']) = olddates
             raise
 
+    def reassign(self, who: str):
+        """
+        transfer ownership to the given user.  To transfer ownership, the calling user must have 
+        "admin" permission on this record.  Note that this will not remove any permissions assigned 
+        to the former owner.
+
+        :param str who:   the identifier for the user to set as the owner of this record
+        :raises NotAuthorized:  if the calling user is not authorized to change the owner.  
+        :raises ValueError:     if the target user identifier is not recognized
+        """
+        if not self.authorized(ACLs.ADMIN):
+            raise NotAuthorized(self._cli.user_id, "change owner")
+
+        # make sure the target user is valid
+        if not self._validate_user_id(who):
+            raise InvalidUpdate("Unable to update owner: invalid user ID: "+str(who))
+
+        self._data['owner'] = who
+        for perm in ACLs.OWN:
+            self.acls.grant_perm_to(perm, who)
+
+    def _validate_user_id(self, who: str):
+        if not bool(who) or not isinstance(who, str):
+            # default test: ensure user is a non-empty string
+            return False
+        if self._cli and self._cli.people_service:
+            return bool(self._cli.people_service.get_person_by_eid(who))
+        return True
+
     def authorized(self, perm: Permissions, who: str = None):
         """
         return True if the given user has the specified permission to commit an action on this record.
@@ -474,7 +505,7 @@ class Group(ProtectedRecord):
     @property
     def name(self):
         """
-        the mnumonic name given to this group by its owner
+        the mnemonic name given to this group by its owner
         """
         return self._data['name']
 
@@ -555,7 +586,7 @@ class DBGroups(object):
     """
     an interface for creating and using user groups.  Each group has a unique identifier assigned to it
     and holds a list of user (and/or group) identities indicating the members of the groups.  In addition
-    to its unique identifier, a group also has a mnumonic name given to it by the group's owner; the 
+    to its unique identifier, a group also has a mnemonic name given to it by the group's owner; the 
     group name need not be globally unique, but it should be unique within the owner's namespace.  
     """
 
@@ -628,7 +659,7 @@ class DBGroups(object):
         """
         return True if a group with the given name exists.  READ permission on the identified 
         record is not required to use this method.
-        :param str name:  the mnumonic name of the group given to it by its owner
+        :param str name:  the mnemonic name of the group given to it by its owner
         :param str owner: the ID of the user owning the group of interest; if not given, the 
                           user ID attached to the `DBClient` is assumed.
         """
@@ -757,14 +788,14 @@ class ProjectRecord(ProtectedRecord):
     @property
     def name(self) -> str:
         """
-        the mnumonic name given to this record by its creator
+        the mnemonic name given to this record by its creator
         """
         return self._data.get('name', "")
 
     @name.setter
     def name(self, val):
         """
-        assign the given name as the record's mnumonic name
+        assign the given name as the record's mnemonic name
         """
         self._data['name'] = val
 
@@ -822,7 +853,8 @@ class DBClient(ABC):
          the only allowed shoulder will be the default, ``grp0``. 
     """
 
-    def __init__(self, config: Mapping, projcoll: str, nativeclient=None, foruser: str = ANONYMOUS):
+    def __init__(self, config: Mapping, projcoll: str, nativeclient=None, foruser: str = ANONYMOUS,
+                 peopsvc: PeopleService = None):
         self._cfg = config
         self._native = nativeclient
         self._projcoll = projcoll
@@ -830,6 +862,7 @@ class DBClient(ABC):
         self._whogrps = None
 
         self._dbgroups = DBGroups(self)
+        self._peopsvc = peopsvc
 
     @property
     def project(self) -> str:
@@ -854,6 +887,14 @@ class DBClient(ABC):
             self.recache_user_groups()
         return self._whogrps
 
+    @property
+    def people_service(self) -> PeopleService:
+        """
+        an attached PeopleService instance or None if such a service is not available.  This service 
+        encapsulates access to the organization's staff directory service.
+        """
+        return self._peopsvc
+
     def recache_user_groups(self):
         """
         the :py:property:`user_groups` contains a cached list of all the groups the user is 
@@ -867,7 +908,7 @@ class DBClient(ABC):
         create (and save) and return a new project record.  A new unique identifier should be assigned
         to the record.
 
-        :param str     name:  the mnumonic name (provided by the requesting user) to give to the 
+        :param str     name:  the mnemonic name (provided by the requesting user) to give to the 
                               record.
         :param str shoulder:  the identifier shoulder prefix to create the new ID with.  
                               (The implementation should ensure that the requested user is authorized 
@@ -964,7 +1005,7 @@ class DBClient(ABC):
         """
         return True if a group with the given name exists.  READ permission on the identified 
         record is not required to use this method.
-        :param str name:  the mnumonic name of the group given to it by its owner
+        :param str name:  the mnemonic name of the group given to it by its owner
         :param str owner: the ID of the user owning the group of interest; if not given, the 
                           user ID attached to the `DBClient` is assumed.
         """
@@ -1282,7 +1323,7 @@ class DBClientFactory(ABC):
     an abstract class for creating client connections to the database
     """
 
-    def __init__(self, config):
+    def __init__(self, config, peopsvc: PeopleService = None):
         """
         initialize the factory with its configuration.  The configuration provided here serves as 
         the default parameters for the cient as these can be overridden by the configuration parameters
@@ -1290,8 +1331,20 @@ class DBClientFactory(ABC):
         the configure the backend storage be provided here, and that the non-storage parameters--namely,
         the ones that control authorization--be provided via :py:method:`create_client` as these can 
         depend on the type of project being access (e.g. "dmp" vs. "dap").
+
+        :param dict          config:  the DBClient configuration
+        :param PeoplService peopsvc:  a PeopleService to use to look up people in the organization.  If
+                                      not provided, an attempt will be made to create one from the 
+                                      configuration (via its ``people_service`` parameter). 
         """
         self._cfg = config
+        self._peopsvc = peopsvc
+
+    def create_people_service(self, config: Mapping = {}):
+        """
+        create a PeopleService that a DBClient can use
+        """
+        return create_people_service(config)
 
     @abstractmethod
     def create_client(self, servicetype: str, config: Mapping = {}, foruser: str = ANONYMOUS):
@@ -1331,6 +1384,92 @@ class DBIORecordException(DBIOException):
     def __init__(self, recid, message, sys=None):
         super(DBIORecordException, self).__init__(message, sys=sys)
         self.record_id = recid
+
+
+class InvalidRecord(DBIORecordException):
+    """
+    an exception indicating that record data is invalid and requires correction or completion.
+
+    The determination of invalid data may result from detailed data validation which may uncover 
+    multiple errors.  The ``errors`` property will contain a list of messages, each describing a
+    validation error encounted.  The :py:meth:`format_errors` will format all these messages into 
+    a single string for a (text-based) display. 
+    """
+    def __init__(self, message: str=None, recid: str=None, part: str=None,
+                 errors: List[str]=None, sys=None):
+        """
+        initialize the exception
+        :param str message:  a brief description of the problem with the user input
+        :param str   recid:  the id of the record that data was provided for
+        :param str    part:  the part of the record that was requested for update.  Do not provide 
+                             this parameter if the entire record was provided.
+        :param [str] errors: a listing of the individual errors uncovered in the data
+        """
+        if errors:
+            if not message:
+                if len(errors) == 1:
+                    message = "Validation Error: " + errors[0]
+                elif len(errors) == 0:
+                    message = "Unknown validation errors encountered"
+                else:
+                    message = "Encountered %d validation errors, including: %s" % (len(errors), errors[0])
+        elif message:
+            errors = [message]
+        else:
+            message = "Unknown validation errors encountered while updating data"
+            errors = []
+        
+        super(InvalidRecord, self).__init__(recid, message, sys)
+        self.record_part = part
+        self.errors = errors
+
+    def __str__(self):
+        out = ""
+        if self.record_id:
+            out += "%s: " % self.record_id
+        if self.record_part:
+            out += "%s: " % self.record_part
+        return out + super().__str__()
+
+    def format_errors(self):
+        """
+        format into a string the listing of the validation errors encountered that resulted in 
+        this exception.  The returned string will have embedded newline characters for multi-line
+        text-based display.
+        """
+        if not self.errors:
+            return str(self)
+
+        out = ""
+        if self.record_id:
+            out += "%s: " % self.record_id
+        out += "Validation errors encountered"
+        if self.record_part:
+            out += " in data submitted to update %s" % self.record_part
+        out += ":\n  * "
+        out += "\n  * ".join([str(e) for e in self.errors])
+        return out
+
+class InvalidUpdate(InvalidRecord):
+    """
+    an exception indicating that the user-provided data is invalid or otherwise would result in 
+    invalid data content for a record. 
+
+    The determination of invalid data may result from detailed data validation which may uncover 
+    multiple errors.  The ``errors`` property will contain a list of messages, each describing a
+    validation error encounted.  The :py:meth:`format_errors` will format all these messages into 
+    a single string for a (text-based) display. 
+    """
+    def __init__(self, message: str=None, recid=None, part=None, errors: List[str]=None, sys=None):
+        """
+        initialize the exception
+        :param str message:  a brief description of the problem with the user input
+        :param str   recid:  the id of the record that data was provided for
+        :param str    part:  the part of the record that was requested for update.  Do not provide 
+                             this parameter if the entire record was provided.
+        :param [str] errors: a listing of the individual errors uncovered in the data
+        """
+        super(InvalidUpdate, self).__init__(message, recid, part, errors, sys)
 
 
 class NotAuthorized(DBIOException):

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1036,7 +1036,7 @@ class DBClient(ABC):
         return a dictionary containing data that will constitue a new ProjectRecord with the given 
         identifier assigned to it.  Generally, this record should not be committed yet.
         """
-        return {"id": id}
+        return {"id": id, "status": {"created_by": self.user_id}}
 
     def exists(self, gid: str) -> bool:
         """

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -333,7 +333,7 @@ class ProtectedRecord(ABC):
 
         :param str who:   the identifier for the user to set as the owner of this record
         :raises NotAuthorized:  if the calling user is not authorized to change the owner.  
-        :raises ValueError:     if the target user identifier is not recognized
+        :raises InvalidUpdate:  if the target user identifier is not recognized or not legal
         """
         if not self.authorized(ACLs.ADMIN):
             raise NotAuthorized(self._cli.user_id, "change owner")

--- a/python/nistoar/midas/dbio/inmem.py
+++ b/python/nistoar/midas/dbio/inmem.py
@@ -9,15 +9,17 @@ from typing import Iterator, List
 from . import base
 
 from nistoar.base.config import merge_config
+from nistoar.nsd.service import PeopleService, MongoPeopleService, create_people_service
 
 class InMemoryDBClient(base.DBClient):
     """
     an in-memory DBClient implementation 
     """
 
-    def __init__(self, dbdata: Mapping, config: Mapping, projcoll: str, foruser: str = base.ANONYMOUS):
+    def __init__(self, dbdata: Mapping, config: Mapping, projcoll: str, foruser: str = base.ANONYMOUS,
+                 peopsvc: PeopleService = None):
         self._db = dbdata
-        super(InMemoryDBClient, self).__init__(config, projcoll, self._db, foruser)
+        super(InMemoryDBClient, self).__init__(config, projcoll, self._db, foruser, peopsvc)
 
     def _next_recnum(self, shoulder):
         if shoulder not in self._db['nextnum']:
@@ -164,5 +166,10 @@ class InMemoryDBClientFactory(base.DBClientFactory):
         cfg = merge_config(config, deepcopy(self._cfg))
         if servicetype not in self._db:
             self._db[servicetype] = {}
-        return InMemoryDBClient(self._db, cfg, servicetype, foruser)
+
+        peopsvc = self._peopsvc
+        if not peopsvc:
+            peopsvc = self.create_people_service(cfg.get("people_service", {}))
+
+        return InMemoryDBClient(self._db, cfg, servicetype, foruser, peopsvc)
         

--- a/python/nistoar/midas/dbio/mongo.py
+++ b/python/nistoar/midas/dbio/mongo.py
@@ -333,6 +333,6 @@ class MongoDBClientFactory(base.DBClientFactory):
         if not peopsvc:
             peopsvc = self.create_people_service(cfg.get("people_service", {}))
 
-        return MongoDBClient(self._dburl, cfg, servicetype, foruser)
+        return MongoDBClient(self._dburl, cfg, servicetype, foruser, peopsvc)
 
 

--- a/python/nistoar/midas/dbio/mongo.py
+++ b/python/nistoar/midas/dbio/mongo.py
@@ -10,6 +10,7 @@ from . import base
 from pymongo import MongoClient, ASCENDING
 
 from nistoar.base.config import ConfigurationException, merge_config
+from nistoar.nsd.service import PeopleService, MongoPeopleService, create_people_service
 
 _dburl_re = re.compile(r"^mongodb://(\w+(:\S+)?@)?\w+(\.\w+)*(:\d+)?/\w+(\?\w.*)?$")
 
@@ -20,7 +21,8 @@ class MongoDBClient(base.DBClient):
     ACTION_LOG_COLL = base.PROV_ACT_LOG
     HISTORY_COLL = 'history'
 
-    def __init__(self, dburl: str, config: Mapping, projcoll: str, foruser: str = base.ANONYMOUS):
+    def __init__(self, dburl: str, config: Mapping, projcoll: str, foruser: str = base.ANONYMOUS,
+                 peopsvc: PeopleService = None):
         """
         create the client with its connector to the MongoDB database
 
@@ -28,13 +30,15 @@ class MongoDBClient(base.DBClient):
         :param dict config:  the configuration for the DBClient
         :param str foruser:  the user requesting records from the database; this will be the identity 
                              used to authorize access to its contents
+        :param PeopleService peopsvc:  a PeopleService that the client can use to look up people in the 
+                             organization.
         """
         if not _dburl_re.match(dburl):
             raise ValueError("DBClient: Bad dburl format (need 'mongodb://[USER:PASS@]HOST[:PORT]/DBNAME'): "+
                              dburl)
         self._dburl = dburl
         self._mngocli = None
-        super(MongoDBClient, self).__init__(config, projcoll, None, foruser)
+        super(MongoDBClient, self).__init__(config, projcoll, None, foruser, peopsvc)
 
     def connect(self):
         """
@@ -311,6 +315,24 @@ class MongoDBClientFactory(base.DBClientFactory):
                              dburl)
         self._dburl = dburl
 
+    def create_people_service(self, config: Mapping = {}):
+        """
+        create a PeopleService that a DBClient can use.  This implementation allows for the people 
+        service to be integrated into DBIO's Mongo database; this will be assumed if the ``factory``
+        parameter is "mongo" and either the ``type`` parameter equals "embedded" or the ``db_url``
+        parameter is not given.  
+        """
+        if config.get("factory") == "mongo" and (config.get("embedded") or not config.get("db_url")):
+            return MongoPeopleService(self._dburl)
+        return super(MongoDBClientFactory, self).create_people_service(config)
+
     def create_client(self, servicetype: str, config: Mapping = {}, foruser: str = base.ANONYMOUS):
         cfg = merge_config(config, deepcopy(self._cfg))
+
+        peopsvc = self._peopsvc
+        if not peopsvc:
+            peopsvc = self.create_people_service(cfg.get("people_service", {}))
+
         return MongoDBClient(self._dburl, cfg, servicetype, foruser)
+
+

--- a/python/nistoar/midas/dbio/project.py
+++ b/python/nistoar/midas/dbio/project.py
@@ -159,7 +159,8 @@ class ProjectService(MIDASSystem):
                 foruser = foruser[-1]
                 
         if self.dbcli.user_id == ANONYMOUS:
-            foruser = None
+            # Do we need to be more careful in production by cancelling reassign request?
+            # foruser = None
             self.log.warning("A new record requested for an anonymous user")
 
         prec = self.dbcli.create_record(name, shoulder)
@@ -167,6 +168,8 @@ class ProjectService(MIDASSystem):
 
         prec.status._data["created_by"] = self.who.id  # don't do this: violates encapsulation
         if foruser:
+            if self.dbcli.user_id == ANONYMOUS:
+                self.log.warning("%s wants to reassign new record to %s", self.dbcli.user_id, foruser)
             try:
                 prec.reassign(foruser)  
             except NotAuthorized as ex:

--- a/python/nistoar/midas/dbio/project.py
+++ b/python/nistoar/midas/dbio/project.py
@@ -127,6 +127,8 @@ class ProjectService(MIDASSystem):
 
         user = who.actor if who else None
         self.dbcli = dbclient_factory.create_client(project_type, self.cfg.get("dbio", {}), user)
+        if not self.dbcli.people_service:
+            self.log.warning("No people service available for %s service", project_type)
 
     @property
     def user(self) -> Agent:

--- a/python/nistoar/midas/dbio/status.py
+++ b/python/nistoar/midas/dbio/status.py
@@ -31,6 +31,7 @@ _action_p   = "action"
 _modified_p = "modified"
 _created_p  = "created"
 _message_p  = "message"
+_creatby_p  = "created_by"
 
 # Common record actions
 # 
@@ -114,6 +115,13 @@ class RecordStatus:
         if self.created <= 0:
             return "pending"
         return datetime.fromtimestamp(math.floor(self.created)).isoformat()
+
+    @property
+    def created_by(self) -> str:
+        """
+        a label indicating who originally created the record.  This may be a user ID or an Agent ID.   
+        """
+        return self._data.get(_creatby_p, "unspecified")
 
     @property
     def since(self) -> float:

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -305,6 +305,7 @@ class ProjectNameHandler(ProjectRecordHandler):
             elif "/json" in rctype:
                 name = self.get_json_body()
             else:
+                self.log.debug("Attempt to change %s with unsupported content type: %s", path, rctype)
                 return self.send_error_resp(415, "Unsupported Media Type",
                                             "Input content-type is not supported", self._id)
         except self.FatalError as ex:

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -299,6 +299,8 @@ class ProjectNameHandler(ProjectRecordHandler):
             return self.send_error(400, "Unsupported Format", str(ex))
 
         rctype = self._env.get('CONTENT_TYPE', 'application/json')
+        if rctype == "application/x-www-form-urlencoded":  # default for python requests
+            rctype = "application/json"
         try:
             if rctype == "text/plain":
                 name = self.get_text_body(self.MAX_NAME_LENGTH+1)

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -317,8 +317,10 @@ class ProjectNameHandler(ProjectRecordHandler):
         try:
             prec = self.svc.get_record(self._id)
             if path == "owner":
+                self.log.info("Reassigning ownership of %s from %s to %s", self._id, prec.owner, name)
                 prec.reassign(name)
             else:
+                self.log.info("Changing short name of %s from %s to %s", self._id, prec.name, name)
                 setattr(prec, path, name)
             if not prec.authorized(dbio.ACLs.ADMIN):
                 raise dbio.NotAuthorized(self._dbcli.user_id, "change record "+path)
@@ -328,6 +330,9 @@ class ProjectNameHandler(ProjectRecordHandler):
         except dbio.ObjectNotFound as ex:
             return self.send_error_resp(404, "ID not found",
                                         "Record with requested identifier not found", self._id)
+        except dbio.InvalidUpdate as ex:
+            return self.send_error_resp(400, "Invalid Input",
+                                        "Invalid value provided for %s: %s" % (path, str(ex)), self._id)
 
         if format.name == "text":
             return self.send_ok(getattr(prec, path), contenttype=format.ctype)

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -23,6 +23,9 @@ are handled accordingly:
 ``/{projid}/name`` -- :py:class:`ProjectNameHandler`
      returns (GET) or updates (PUT) the user-supplied name of the record.
 
+``/{projid}/owner`` -- :py:class:`ProjectNameHandler`
+     returns ID of current owner (GET) or reassigns ownership to given ID (PUT).
+
 ``/{projid}/data[/...]`` -- :py:class:`ProjectDataHandler`
      returns (GET), updates (PUT, PATCH), or clears (DELETE) the data content of the record.  This
      implementation supports updating individual parts of the data object via PUT, PATCH, DELETE 

--- a/python/nistoar/nsd/client.py
+++ b/python/nistoar/nsd/client.py
@@ -10,6 +10,7 @@ import urllib.request, urllib.parse, urllib.error
 import requests
 
 from . import NSDException, NSDServerError, NSDClientError, NSDResourceNotFound
+from nistoar.base.config import ConfigurationException
 
 NISTOrg = namedtuple('NISTOrg', "id title abbrev number")
 _org_prop_nm = {
@@ -28,13 +29,15 @@ class NSDClient:
     GROUP_EP = "/NISTGroup"
     PEOPLE_EP = "/People/list"
 
-    def __init__(self, baseurl, restrict_ou: List[str]=None):
+    def __init__(self, baseurl, authconfig: Mapping=None, restrict_ou: List[str]=None):
         """
         initialize the client
-        :param str baseurl:  the base URL for the service.  This should include everything up to 
-                             (and including) the version field (e.g. "https://..../.../v1").
+        :param str     baseurl:  the base URL for the service.  This should include everything up to 
+                                 (and including) the version field (e.g. "https://..../.../v1").
+        :param str  authconfig:  a dictionary providing credentials for connecting to the service; if 
+                                 not provided, it will be assumed that authentication is not required.
         :param str restrict_ou:  if non-None, restrict people search results to those who are 
-                             members of OUs in the given list of OU abbreviated names (e.g. "MML"). 
+                                 members of OUs in the given list of OU abbreviated names (e.g. "MML"). 
         """
         self.baseurl = baseurl.rstrip('/')
         if restrict_ou and not isintance(restrict_ou, list):
@@ -42,13 +45,68 @@ class NSDClient:
         self._def_ou = restrict_ou
         self._ou_nums = None
 
+        self._authkw = {}
+        self._authhdr = {}
+        self._setup_auth(authconfig)
+
+    def _setup_auth(self, config: Mapping=None):
+        # erase any previously set-up authentication
+        self._authkw = {}
+        self._authhdr = {}
+
+        if not config or config.get('type', '') is None:
+            return      # no authentication required
+
+        authtype = config.get('type', 'bearer')
+        if isinstance(authtype, str):
+            authtype = authtype.lower()
+
+        if authtype == "none":
+            pass      # no authentication required
+
+        elif authtype == "userpass":
+            self._authkw = { "user": (config.get('user'), config.get('pass')) }
+            if not all(self._authkw["user"]):
+                raise ConfigurationException("NSDClient: authentication type userpass requires both "+
+                                             "'user' and 'pass' config parameters")
+
+        elif authtype == "bearer":
+            token = config.get("token")
+            if not token:
+                raise ConfigurationException("NSDClient: authentication type bearer requires "+
+                                             "'token' config parameter")
+            self._authhdr = { "Authorization": f"Bearer {token}" }
+
+        elif authtype == "cert":
+            self._authkw = { 'cert': (config.get('client_cert_path'), config.get('client_key_path')) }
+            if not all(self._authkw["cert"]):
+                raise ConfigurationException("NSDClient: authentication type userpass requires both "+
+                                             "'user' and 'pass' config parameters")
+
+            unreadable = []
+            for cfile in self._authkw['cert']:
+                try:
+                    with open(cfile) as fd:
+                        pass
+                except OSError as ex:
+                    unreadable.append(f"{cfile} ({str(ex)})")
+            if unreadable:
+                s = "s" if len(unreadable) > 1 else ""
+                raise ConfigurationException("NSDClient: certificate file%s unreadable:\n  %s" %
+                                             (s, "\n  ".join(unreadable)))
+
+        else:
+            raise ConfigurationException("NSDClient: authentication 'type' param value not supported: "+
+                                         authtype)
+            
+
     def _get(self, relurl):
         if not relurl.startswith('/'):
             relurl = '/'+relurl
-        hdrs = { }
+        hdrs = self._authhdr
         
         try:
-            resp = requests.get(self.baseurl+relurl, headers=hdrs)
+            resp = requests.get(self.baseurl+relurl, headers=hdrs, **self._authkw)
 
             if resp.status_code >= 500:
                 raise NSDServerError(relurl, resp.status_code, resp.reason)
@@ -84,9 +142,10 @@ class NSDClient:
         if not relurl.startswith('/'):
             relurl = '/'+relurl
         hdrs = { "Content-type": "application/json" }
+        hdrs.update(self._authhdr)
         
         try:
-            resp = requests.post(self.baseurl+relurl, headers=hdrs, json=filter)
+            resp = requests.post(self.baseurl+relurl, headers=hdrs, json=filter, **self._authkw)
 
             if resp.status_code >= 500:
                 raise NSDServerError(relurl, resp.status_code, resp.reason)

--- a/python/nistoar/web/formats.py
+++ b/python/nistoar/web/formats.py
@@ -247,7 +247,7 @@ class JSONSupport(FormatSupport):
     @classmethod
     def add_support(cls, fmtsup: FormatSupport, ctypes: List[str]=[], asdefault: bool=False):
         """
-        Add support for HTML content types to the given FormatSupport instance
+        Add support for JSON content types to the given FormatSupport instance
         """
         if not ctypes:
             ctypes = [ JSONSupport.DEF_CONTENT_TYPE ]

--- a/python/nistoar/web/rest/base.py
+++ b/python/nistoar/web/rest/base.py
@@ -55,7 +55,7 @@ class Handler(object):
 
         # the output formats supported by this Handler; if None, the client has no choice
         # over the output format.  This should be set at construction time via
-        # set_default_format_support()
+        # _set_default_format_support()
         self._fmtsup = None
         
         # set to the name of the query parameter for requesting a named format (e.g. "format")

--- a/python/tests/nistoar/midas/dap/service/test_mds3_app.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3_app.py
@@ -103,7 +103,7 @@ class TestMDS3DAPApp(test.TestCase):
         hdlr = self.app.create_handler(req, self.start, path, nistr)
         self.assertTrue(isinstance(hdlr, prj.ProjectNameHandler))
         self.assertNotEqual(hdlr.cfg, {})
-        self.assertEqual(hdlr._path, "")
+        self.assertEqual(hdlr._path, "name")
         self.assertEqual(hdlr._id, "mdm1:0001")
 
     def test_get_name(self):

--- a/python/tests/nistoar/midas/dap/service/test_mds3_app_wfm.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3_app_wfm.py
@@ -139,7 +139,7 @@ class TestMDS3DAPApp(test.TestCase):
         hdlr = self.app.create_handler(req, self.start, path, nistr)
         self.assertTrue(isinstance(hdlr, prj.ProjectNameHandler))
         self.assertNotEqual(hdlr.cfg, {})
-        self.assertEqual(hdlr._path, "")
+        self.assertEqual(hdlr._path, "name")
         self.assertEqual(hdlr._id, "mdm1:0001")
 
     def test_get_name(self):

--- a/python/tests/nistoar/midas/dbio/test_project.py
+++ b/python/tests/nistoar/midas/dbio/test_project.py
@@ -117,6 +117,7 @@ class TestProjectService(test.TestCase):
         self.assertEqual(prec.status.action, "create")
         self.assertEqual(prec.status.message, "draft created")
         self.assertEqual(prec.status.state, "edit")
+        self.assertEqual(prec.status.created_by, "midas/nstr1")
 
         self.assertEqual(prec.acls._perms.get("read"), [ self.project.who.actor, "grp0:public"])
         self.assertEqual(prec.acls._perms.get("write"), [ self.project.who.actor ])
@@ -147,6 +148,18 @@ class TestProjectService(test.TestCase):
         self.assertEqual(prec.id, "mdm1:0003")
         self.assertEqual(prec.data, {"color": "red"})
         self.assertEqual(prec.meta, {"temper": "dark", "agent_vehicle": 'midas'})
+
+    def test_create_record_reassign(self):
+        self.create_service()
+        self.assertTrue(not self.project.dbcli.name_exists("gurn"))
+        
+        prec = self.project.create_record("gurn", {"color": "red"}, {"foruser": "harry"})
+        self.assertEqual(prec.name, "gurn")
+        self.assertEqual(prec.id, "mdm1:0003")
+        self.assertEqual(prec.data, {"color": "red"})
+        self.assertEqual(prec.owner, "harry")
+        self.assertEqual(prec.meta, {"foruser": "harry", "agent_vehicle": 'midas'})
+        self.assertEqual(prec.status.created_by, "midas/nstr1")
 
     def test_get_data(self):
         self.create_service()

--- a/python/tests/nistoar/midas/dbio/wsgi/test_project.py
+++ b/python/tests/nistoar/midas/dbio/wsgi/test_project.py
@@ -620,6 +620,58 @@ class TestMIDASProjectApp(test.TestCase):
         self.assertEqual(resp['id'], "mdm1:0003")
         self.assertEqual(resp['data'], {"color": "red"})
         self.assertEqual(resp['meta'], {})
+        self.assertEqual(resp['status']['created_by'], "dbio/nstr1")
+
+        # test reassign on creation: via meta
+        self.resp = []
+        req['wsgi.input'] = StringIO(json.dumps({"name": "else", "owner": "nobody",
+                                                 "meta": {"foruser": "harry"}}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        self.assertTrue(isinstance(hdlr, prj.ProjectSelectionHandler))
+        self.assertNotEqual(hdlr.cfg, {})
+        self.assertEqual(hdlr._path, "")
+        body = hdlr.handle()
+        self.assertIn("201 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertEqual(resp['name'], "else")
+        self.assertEqual(resp['owner'], "harry")
+        self.assertEqual(resp['id'], "mdm1:0004")
+        self.assertEqual(resp['meta'], {"foruser": "harry", "agent_vehicle": "dbio"})
+        self.assertEqual(resp['status']['created_by'], "dbio/nstr1")
+
+        # test reassign on creation: via query parameter
+        self.resp = []
+        req['QUERY_STRING'] = "foruser=True"
+        req['wsgi.input'] = StringIO(json.dumps({"name": "else", "owner": "nobody"}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        self.assertTrue(isinstance(hdlr, prj.ProjectSelectionHandler))
+        self.assertNotEqual(hdlr.cfg, {})
+        self.assertEqual(hdlr._path, "")
+        body = hdlr.handle()
+        self.assertIn("201 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertEqual(resp['name'], "else")
+        self.assertEqual(resp['owner'], "nobody")
+        self.assertEqual(resp['id'], "mdm1:0005")
+        self.assertEqual(resp['meta'], {"foruser": "nobody", "agent_vehicle": "dbio"})
+        self.assertEqual(resp['status']['created_by'], "dbio/nstr1")
+
+        # test reassign on creation: via query parameter
+        self.resp = []
+        req['QUERY_STRING'] = "foruser=sally"
+        req['wsgi.input'] = StringIO(json.dumps({"name": "else", "owner": "nobody"}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        self.assertTrue(isinstance(hdlr, prj.ProjectSelectionHandler))
+        self.assertNotEqual(hdlr.cfg, {})
+        self.assertEqual(hdlr._path, "")
+        body = hdlr.handle()
+        self.assertIn("201 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertEqual(resp['name'], "else")
+        self.assertEqual(resp['owner'], "sally")
+        self.assertEqual(resp['id'], "mdm1:0006")
+        self.assertEqual(resp['meta'], {"foruser": "sally", "agent_vehicle": "dbio"})
+        self.assertEqual(resp['status']['created_by'], "dbio/nstr1")
 
     def test_delete(self):
         path = ""

--- a/python/tests/nistoar/nsd/test_service.py
+++ b/python/tests/nistoar/nsd/test_service.py
@@ -257,6 +257,20 @@ class TestMongoPeopleService(test.TestCase):
         self.assertEqual(stat['person_count'], 4)
         self.assertEqual(stat['org_count'], 8)
         self.assertTrue(stat['message'].startswith("Ready"))
+
+    def test_get_person_by(self):
+        self.svc.load(self.cfg, rootlog, False)
+
+        who = self.svc.get_person_by_eid("pgp1")
+        self.assertIsNotNone(who)
+        self.assertEqual(who["lastName"], "Proctor")
+
+        who = self.svc.get_person_by_email("phillip.austin@nist.gov")
+        self.assertIsNotNone(who)
+        self.assertEqual(who["lastName"], "Austin")
+
+        
+        
         
                          
 if __name__ == '__main__':


### PR DESCRIPTION
The aim of this PR is to allow changing the owner of a DBIO record through the web API.  To validate the new user ID as valid and recognized, access to the people service is made available to the `dbio.DBClient`.  This is done via the `PeopleService` which has a direct connection to the MongoDB collections (rather than through a web API).  The `mds3` DAP service was updated to use this same `PeopleService` instance (switching from the `NSDClient` which goes through the web API).  To make use of the people service, the dbio configuration must include a `people_service` parameter. 

When the ownership is changed to a new user, the service will also update the ACLs to give all permissions to the new user.  The permissions for the old user are _not_ removed.

As a convenience, the API was updated to allow clients to request and update the record's name and owner using a plain text (by setting the `Content-Type` header to `text/plain`) instead of the default JSON format.

To test, it is recommended to run under `oar-docker`, `MIDASbeta` branch, setting the tag for `dbio` to this branch in the `deployment.yml` file.