### PR TITLE
Fix code scanning errors

### DIFF
--- a/python/nistoar/pdr/preserve/bagit/builder.py
+++ b/python/nistoar/pdr/preserve/bagit/builder.py
@@ -33,6 +33,7 @@ from multibag import open_headbag
 
 NORM=15  # Log Level for recording normal activity
 logging.addLevelName(NORM, "NORMAL")
+
 # log = logging.getLogger(__name__)
 
 DEF_BAGLOG_FORMAT = "%(asctime)s %(levelname)s: %(message)s"
@@ -70,6 +71,14 @@ NERDM_CONTEXT = "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld"
 DISTSERV = "https://"+PDR_PUBLIC_SERVER+"/od/ds/"
 DEF_MERGE_CONV = "pdp0"
 FILECMP_ID_START = FILECMP_EXTENSION.strip('/') + '/'
+
+def mask_sensitive_data(data):
+    """
+    Masks sensitive data such as phone numbers by redacting all but the last 4 digits.
+    """
+    if not data or len(data) <= 4:
+        return data
+    return '*' * (len(data) - 4) + data[-4:]
 
 class BagBuilder(PreservationSystem):
     """
@@ -2437,8 +2446,8 @@ class BagBuilder(PreservationSystem):
                             print("         {0}".format(line.strip()),
                                   file=fd)
                     if 'phoneNumber' in cp:
-                        print("         Phone: {0}".format(cp['phoneNumber'].strip()),
-                              file=fd)
+                        masked_phone = mask_sensitive_data(cp['phoneNumber'].strip())
+                        print("    Phone: {0}".format(masked_phone), file=fd)
                     fd.write("\n")
 
                 # description

--- a/python/nistoar/pdr/preserve/bagit/tools/enhance.py
+++ b/python/nistoar/pdr/preserve/bagit/tools/enhance.py
@@ -118,7 +118,7 @@ def update_authors(bagbldr, as_annot=False, config=None):
     return AuthorFetcher(config).update_authors(bagbldr, as_annot)
 
 
-_altdoifmt = re.compile('^((https?://dx.doi.org/)|(doi:))')
+_altdoifmt = re.compile('^((https?://dx\.doi\.org/)|(doi:))')
 def normalize_doi(doi):
     """
     convert a DOI recognized as using an alternate format (i.e., beginning with "doi:" or 

--- a/python/tests/nistoar/pdr/publish/bagger/test_datachecker.py
+++ b/python/tests/nistoar/pdr/publish/bagger/test_datachecker.py
@@ -75,7 +75,7 @@ def tearDownModule():
 def mk_dlurls_local(bagdir):
     # convert the download urls so that they point to the local
     # sim dist service
-    datadotnist = re.compile(r'^https://data.nist.gov/')
+    datadotnist = re.compile(r'^https://data\.nist\.gov/')
 
     mddir = os.path.join(bagdir, "metadata")
     for (dpath, dirs, files) in os.walk(mddir):


### PR DESCRIPTION
This PR fixes three errors pointed by GitHub Advanced Security Code scanning feature:
- Clear-text logging of sensitive information
- Incomplete regular expression for hostnames
- Incomplete regular expression for hostnames

Please see the screenshot below indicating code scan fix done on my fork of the repo.
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/c725fb5b-2c70-4678-90d3-dc60bb99948c" />

Please review @nikblonder @Iskander54 @RayPlante  / other project contributors.