### PR TITLE
Integrate client notifier service into standalone midasserver, improve configurability

### DIFF
--- a/docker/midasserver/entrypoint.sh
+++ b/docker/midasserver/entrypoint.sh
@@ -3,6 +3,10 @@
 port=9091
 script=/dev/oar-pdr-py/scripts/midas-uwsgi.py
 [ -f "$script" ] || script=/app/dist/pdr/bin/midas-uwsgi.py
+midas_config=/app/midas-config.yml
+clinotif_config=/app/midas-clinotif.yml
+clinotif_key=123456_secret_key
+clinotif_server="python3 /app/dist/pdr/bin/websocket_server.py"
 
 [ -n "$OAR_WORKING_DIR" ] || OAR_WORKING_DIR=`mktemp --tmpdir -d _midasserver.XXXXX`
 [ -d "$OAR_WORKING_DIR" ] || {
@@ -10,7 +14,7 @@ script=/dev/oar-pdr-py/scripts/midas-uwsgi.py
     exit 10
 }
 [ -n "$OAR_LOG_DIR" ] || export OAR_LOG_DIR=$OAR_WORKING_DIR
-[ -n "$OAR_MIDASSERVER_CONFIG" ] || OAR_MIDASSERVER_CONFIG=/app/midas-config.yml
+[ -n "$OAR_MIDASSERVER_CONFIG" ] || OAR_MIDASSERVER_CONFIG=$midas_config
 
 echo
 echo Working Dir: $OAR_WORKING_DIR
@@ -21,6 +25,33 @@ opts=
 oar_midas_db_type=$1
 [ -z "$oar_midas_db_type" ] || opts="--set-ph oar_midas_db_type=$oar_midas_db_type"
 [ -z "$OAR_LOG_FILE" ] || opts="$opts --set-ph oar_log_file=$OAR_LOG_FILE"
+
+# use a client notification server?
+use_clinotif_config=
+[ -z "$OAR_CLINOTIF_URL" ] || {
+    use_clinotif_config=/tmp/client_notifier_config.yml
+    touch $use_clinotif_config
+    [ \! -f "$clinotif_config" ] || cp $clinotif_config $use_clinotif_config
+    if { echo $OAR_CLINOTIF_URL | grep -qs '^ws:'; }; then
+        # an external server is running
+        echo service_endpoint: $OAR_CLINOTIF_URL >> $use_clinotif_config
+        [ -n "$OAR_CLINOTIF_KEY" ] || OAR_CLINOTIF_KEY=$clinotif_key
+        echo broadcast_key: $OAR_CLINOTIF_KEY >> $use_clinotif_config
+    else
+        # we're launching our own
+        echo service_endpoint: ws://localhost:8765 >> $use_clinotif_config
+        echo port: 8765 >> $use_clinotif_config
+        broadkey=`python3 -c 'import uuid; print(uuid.uuid4())'`
+        echo broadcast_key: $broadkey >> $use_clinotif_config
+
+        # launch it
+        echo '++' nohup $clinotif_server -l $OAR_LOG_DIR/client_notifier.log --config $use_clinotif_config
+        nohup $clinotif_server -l $OAR_LOG_DIR/client_notifier.log --config $use_clinotif_config 2>&1 >> $OAR_LOG_DIR/nohup.log &
+    fi
+}
+[ -z "$use_clinotif_config" ] || \
+    opts="$opts --set-ph dbio_clinotif_config_file=$use_clinotif_config"
+
 
 echo '++' uwsgi --plugin python3 --http-socket :$port --wsgi-file $script --static-map /docs=/docs \
                 --set-ph oar_config_file=$OAR_MIDASSERVER_CONFIG \

--- a/python/nistoar/midas/dbio/notifier.py
+++ b/python/nistoar/midas/dbio/notifier.py
@@ -1,18 +1,34 @@
+"""
+a module that allows the DBIO to alert listening clients about changes and updates made to 
+DBIO's data contents.  The DBIO's interface into this capability is the 
+:py:class:`DBIOClientNotifier`.  
+"""
 import asyncio
 import websockets
 import logging
+from logging import Logger
 
-# Configure logging
-logger = logging.getLogger(__name__)
+deflogger = logging.getLogger(__name__)
 
-class Notifier:
-    def __init__(self, uri, api_key=None):
+class DBIOClientNotifier:
+    """
+    A class that provides an interface for sending messages DBIO listeners in which the DBIO plays
+    the role of a message "broadcaster".
+
+    This implemenation uses a websocket server.  The server recognizes this client as a broadcaster
+    of messages via its use of a broadcast key.  
+    """
+    def __init__(self, uri: str, broadcast_key: str=None, logger: Logger=None):
         """
-        Initialize the Notifier with the WebSocket server URI.
-        :param str uri: The WebSocket server address.
+        Create the notifier
+        :param str uri:  the websocket server address
+        :param str broadcast_key: a key that identifies this client to the serve as a broadcaster.
         """
         self.uri = uri
-        self.api_key = api_key
+        self.api_key = broadcast_key
+        if not logger:
+            logger = deflogger
+        self.log = logger
 
     def notify(self, message):
         """
@@ -23,33 +39,33 @@ class Notifier:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             # No running event loop; create a new one
-            logger.debug("No running event loop found. Creating a new event loop.")
+            self.log.debug("No running event loop found. Creating a new event loop.")
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
 
         if not loop.is_running():
-            logger.debug("Event loop is not running. Starting the event loop.")
+            self.log.debug("Event loop is not running. Starting the event loop.")
             loop.run_until_complete(self._send_notification(message))
         else:
             future = asyncio.run_coroutine_threadsafe(self._send_notification(message), loop)
-            logger.info(f"Notification coroutine submitted to the event loop: {future}")
+            self.log.info(f"Notification coroutine submitted to the event loop: {future}")
 
     async def _send_notification(self, message):
         """
         Coroutine to send a notification message via WebSocket.
         :param str message: The message to send.
         """
-        logger.debug(f"Connecting to WebSocket server at {self.uri}...")
+        self.log.debug(f"Connecting to WebSocket server at {self.uri}...")
         try:
             async with websockets.connect(self.uri) as websocket:
                 if self.api_key:
                     
-                    logger.info(f"Sending WebSocket message: {message}")
+                    self.log.info(f"Sending WebSocket message: {message}")
                     authentified_message = f"{self.api_key},{message}"
                     await websocket.send(authentified_message)
-                    logger.debug("WebSocket message sent successfully.")
+                    self.log.debug("WebSocket message sent successfully.")
                     
                 await websocket.close()
-                logger.debug("WebSocket connection closed cleanly.")
+                self.log.debug("WebSocket connection closed cleanly.")
         except Exception as e:
-            logger.error(f"Error sending WebSocket message: {e}")
+            self.log.error(f"Error sending WebSocket message: {e}")

--- a/scripts/midas-uwsgi.py
+++ b/scripts/midas-uwsgi.py
@@ -170,3 +170,5 @@ print(msg)
 logging.info(msg)
 if nsdcfg:
     logging.info("...and NSD service built-in")
+if cfg.get('dbio', {}).get('client_notifier'):
+    logging.info("...and with client notifier")

--- a/scripts/midas-uwsgi.py
+++ b/scripts/midas-uwsgi.py
@@ -90,6 +90,12 @@ if uwsgi.opt.get("oar_log_file"):
 
 config.configure_log(config=cfg)
 
+# Is there a client notification service running we should talk to?
+if uwsgi.opt.get('dbio_clinotif_config_file'):
+    cnscfg = config.resolve_configuration(_dec(uwsgi.opt['dbio_clinotif_config_file']))
+    cfg.setdefault('dbio', {})
+    cfg['dbio']['client_notifier'] = cnscfg
+
 # setup the MIDAS database backend
 dbtype = _dec(uwsgi.opt.get("oar_midas_db_type"))
 if not dbtype:

--- a/scripts/websocket_server.py
+++ b/scripts/websocket_server.py
@@ -1,34 +1,98 @@
+"""
+A stand-alone server application allowing a broadcaster to send messages to connected clients
+
+To run this server with a default configuration, type:
+
+    python3 client_notifier_server.py
+
+To display the available command-line options for this server, type:
+
+    python3 client_notifier_server.py --help
+
+This server provides a websocket endpoint for a broadcaster and any number of clients to connect
+(the default is ws://localhost:8735).  Messages sent by a client are ignored; messages sent by 
+the broadcaster are sent out to all connected clients.
+
+Messages are (mostly) arbitrary, comma-delimited strings. Each substring between commas are fields
+of the message.  Messages whose first field is a token that matches configured authorization key 
+identifies the sender as a broadcaster.  The message will be sent to all connected clients with 
+the authorization key removed.  
+"""
 import asyncio
 import websockets
 import logging
 import argparse
+import os
+import sys
+import traceback
 
-logging.basicConfig(level=logging.INFO)
+try:
+    import nistoar
+except ImportError:
+    if os.environ.get('OAR_PYTHONPATH'):
+        sys.path.append(os.environ['OAR_PYTHONPATH'])
+    elif os.environ.get('OAR_HOME'):
+        sys.path.append(os.path.join(os.environ['OAR_HOME'], "lib", "python"))
 
-class WebSocketServer:
-    def __init__(self, host="0.0.0.0", port=8765, api_key="123456_secret_key"):
-        self.host = host
-        self.port = port
-        self.api_key = api_key
+def_broadcast_key="123456_secret_key"
+def_port=8765
+def_host="0.0.0.0"
+
+class WebClientNotifierServer:
+    """
+    the server class that implements the broadcasting service using Web Sockets.
+
+    Broadcasters and clients connect to the same web socket endpoint ("ws://host:port/").
+    Any message sent by a client is ignored; a message sent by a broadcaster are sent out
+    to all the connected clients (and any other broadcasters).  
+
+    All messages is an arbitrary, comma-delimited string.  Each substring between commas is 
+    message field.  A broadcast message is recognized as such if its first field is a token
+    that matches a broadcast authorization key set at construction time.  This token is 
+    removed from the field before it is distributed to all other clients.
+    """
+    def __init__(self, host=None, port=None, broadcast_key=None, config=None):
+        """
+        create the server.
+        :param str host:   the name or ip address representing the local network interface
+                           that this server will be listening on (default: "0.0.0.0")
+        :param str port:   the port the server will listen on (default: 8765)
+        :param str broadcast_key:  a token that identifies a broadcaster.  A broadcaster
+                           must include this key as the first field of all messages.  
+        :param dict config:  a dictionary of parameters that serve as default configuration
+                           values.  This constructor will look for keys matching the other 
+                           parameters specified in this function signature which will be used 
+                           if the argument is not provided to this constructor explicitly.
+        """
+        self.host = host or config.get('host') or def_host
+        self.port = port or config.get('port') or def_port
+        self.bk_key = broadcast_key or config.get('broadcast_key') or def_broadcast_key
         self.clients = set()
+        self.log = logging.getLogger("client_notifier")
 
     async def handler(self, websocket):
+        """
+        handle a connection to a client or broadcaster
+        """
         self.clients.add(websocket)
         try:
             async for message in websocket:
-                logging.info(f"Received message: {message}")
-                logging.info(f"Authenticating message: {self.api_key}")
-
                 if not self._authenticate_message(message):
-                    logging.warning("Unauthorized message received. Ignoring.")
+                    self.log.warning("Ignoring unauthorized message: %s", message)
                     continue
 
                 _, message_content = message.split(",", 1)
+                await asyncio.gather(*(client.send(message_content)
+                                       for client in self.clients if client != websocket))
 
-                await asyncio.gather(*(client.send(message_content) for client in self.clients if client != websocket))
-                logging.info(f"Message distributed to {len(self.clients) - 1} clients: {message_content}")
+                self.log.info("Message distributed to %d client%s: %s", len(self.clients) - 1,
+                              "s" if len(self.clients) != 2 else "", message_content)
+
         except websockets.ConnectionClosed:
-            logging.info("Client disconnected")
+            self.log.info("Client disconnected")
+        except Exception as ex:
+            self.log.error("Unexpected communication error: %s; closing client", str(ex))
+            websocket.close(1002)
         finally:
             self.clients.remove(websocket)
 
@@ -41,22 +105,76 @@ class WebSocketServer:
         try:
             # Expect the message to be in the format: "api_key,message_content"
             api_key, _ = message.split(",", 1)
-            return api_key == self.api_key
+            return api_key == self.bk_key
         except ValueError:
             # Message format is invalid
-            logging.error("Invalid message format. Expected 'api_key,message_content'.")
+            self.log.error("Invalid message format. Expected 'broadcast_key,message_content'.")
             return False
 
     async def main(self):
         async with websockets.serve(self.handler, self.host, self.port):
-            logging.info(f"WebSocket server started on ws://{self.host}:{self.port}")
+            self.log.info(f"WebSocket server started on ws://{self.host}:{self.port}")
             await asyncio.Future()  # Run forever
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Start the WebSocket server.")
-    parser.add_argument("--port", type=int, default=8765, help="The port to run the WebSocket server on (default: 8765).")
-    parser.add_argument("--api_key", type=str, default="123456_secret_key", help="The API key for authenticating messages from DBIO.")
-    args = parser.parse_args()
+def define_options(progname):
+    global def_broadcast_key
+    parser = argparse.ArgumentParser(progname, description="Start the Client Notifier server.")
+                        
+    parser.add_argument("-p", "--port", type=int, default=None, metavar="PORT", dest='port',
+                        help="The port to run the WebSocket server on (default: 8765).")
+    parser.add_argument("-k", "--broadcast-key", type=str, dest='bkey', metavar="KEY", default=None,
+                        help="The authorization key for identifing messages from DBIO.")
+    parser.add_argument("-c", "--config-file", type=str, metavar="FILE", dest='config',
+                        help="load server configuration data from FILE.  Other command line " +
+                             "options will override the configuration.  It is preferred to " +
+                             "provide the broadcast key in a configuration file rather than " +
+                             "on the command-line when running in production.")
+    parser.add_argument("-v", "--verbose", action="store_true", dest='verbose', default=False,
+                        help="include debug messages in logging output")
+    parser.add_argument("-l", "--logfile", type=str, metavar="FILE", dest='logfile',
+                        help="send logging messages to FILE instead of standard error")
 
-    server = WebSocketServer(host="0.0.0.0", port=args.port, api_key=args.api_key)
+    return parser
+
+
+class CLIError(Exception):
+    pass
+
+def main(progname, args):
+    parser = define_options(progname)
+    opts = parser.parse_args(args)
+
+    cfg = { }
+    if opts.config:
+        from nistoar.base import config
+        cfg = config.resolve_configuration(opts.config)
+
+        # set up logging from config
+        extra = { }
+        if opts.verbose:
+            extra['level'] = logging.DEBUG
+        config.configure_log(logfile=opts.logfile, config=cfg, addstderr=True, **extra)
+
+    else:
+        # default logging
+        lev = logging.DEBUG if opts.verbose else logging.INFO
+        fmt = "%(name)s: %(levelname)s: %(message)"
+        logging.basicConfig(level=lev, format=fmt)
+        
+    # launch the server (Note: None args will defer to config/defaults)
+    server = WebClientNotifierServer(None, opts.port, opts.bkey, config=cfg)
     asyncio.run(server.main())
+
+
+if __name__ == "__main__":
+    progname = sys.argv[0]
+    try:
+        main(progname, sys.argv[1:])
+    except CLIError as ex:
+        print(f"{progname}: {str(ex)}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as ex:
+        print(f"Unexpected error: {str(ex)}", file=sys.stderr)
+        traceback.print_tb(sys.exc_info()[2])
+        sys.exit(4)
+

--- a/scripts/websocket_server.py
+++ b/scripts/websocket_server.py
@@ -158,7 +158,7 @@ def main(progname, args):
     else:
         # default logging
         lev = logging.DEBUG if opts.verbose else logging.INFO
-        fmt = "%(name)s: %(levelname)s: %(message)"
+        fmt = "%(asctime)s %(name)s: %(levelname)s: %(message)s"
         logging.basicConfig(level=lev, format=fmt)
         
     # launch the server (Note: None args will defer to config/defaults)


### PR DESCRIPTION
This PR builds on the recent addition of the websocket server used to notify DBIO clients about DBIO content changes (specifically, new records).  The primary aim is to integrate use of the notification service into the standalone `midasserver`; however, to make this possible, it was important to improve the configurability of both the notification server (`websocket_server.py`) and the client class used by the DBIO code.  

Other related changes include:
  * renaming the server and client classes to reflect their purpose over their implementation
  * tweaking logging

Please test in two ways:
  * standalone: 
     1. check out this branch
     2. start up standalone server with a websocket server (via `-N`): 
         `scripts/midasserver -b -D --bg -M -P -N midasdata start`
     3. check websocket log (`midasdata/client_notifier.log`) to confirm startup of server
     4. create a record via 
         `curl -vk --data '{"name": "test"}' https://localhost:9091/midas/dmp/mdm1`
     5. check websocket log again for messages confirming broadcast message
     6. shutdown server: 
         `scripts/midasserver -M -P -N midasdata stop`

  * under oar-docker:
     1. check out the `test/websocket` branch of `oar-docker`
     2. build and launch
     3. access the portal page
     4. check log `data/logs/midas/websocket_server.log` to confirm start-up and connection from portal
     5. create a new DMP or DAP 
     6. confirm dynamic update of portal listing

