### PR TITLE
Change endpoint from GET to POST for export

### DIFF
--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -828,7 +828,7 @@ class ProjectSelectionHandler(ProjectRecordHandler):
             return self.send_error_resp(400, "Bad POST input", "No record IDs provided")
 
         fmt_name = (input.get("format") or "json").strip().lower()
-        perms = input.get("permissions") or dbio.ACLs.OWN
+        perms = input.get("permissions") or dbio.ACLs.OWN   # OWN=any of all perms
 
         recs = self._sort_and_format_records(self._select_records(perms, id=ids))
         if not recs:

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -772,7 +772,7 @@ class ProjectSelectionHandler(ProjectRecordHandler):
 
         elif path == ':selected':
             # respond to an advanced search
-            try: 
+            try:
                 return self.adv_select_records(input)
             except SyntaxError as syntax:
                 return self.send_error(400, "Wrong query structure for filter")
@@ -780,7 +780,10 @@ class ProjectSelectionHandler(ProjectRecordHandler):
                 return self.send_error(204, "No Content")
             except AttributeError as attribute:
                 return self.send_error(400, "Attribute Error, not a json")
-        
+
+        elif path == ':export':
+            return self.export_selected_records(input)
+
         else:
             return self.send_error(400, "Selection resource not found")
 
@@ -807,12 +810,39 @@ class ProjectSelectionHandler(ProjectRecordHandler):
 
     def _adv_select_records(self, filter, perms) -> Iterator[ProjectRecord]:
         """
-        submit the advanced search query in a project-specific way. This method is provided as a 
-        hook to subclasses that may need to specialize the search strategy or manipulate the results.  
+        submit the advanced search query in a project-specific way. This method is provided as a
+        hook to subclasses that may need to specialize the search strategy or manipulate the results.
         This base implementation passes the query directly to the generic DBClient instance.
         :return:  a generator that iterates through the matched records
         """
         return self._dbcli.adv_select_records(filter, perms)
+
+    def export_selected_records(self, input: Mapping):
+        """
+        export records identified by IDs provided in the request body.
+        Expects: {"ids": ["id1", "id2", ...], "format": "pdf"|"csv"|"markdown"}
+        """
+        ids = input.get("ids", [])
+        if not ids:
+            return self.send_error_resp(400, "Bad POST input", "No record IDs provided")
+
+        fmt_name = input.get("format", "")
+        supp_fmts = FormatSupport()
+        supp_fmts.support(Format("pdf", "application/pdf"))
+        supp_fmts.support(Format("markdown", "text/markdown"))
+        supp_fmts.support(Format("csv", "text/csv"))
+        fmt = supp_fmts.match(fmt_name)
+        if not fmt:
+            return self.send_error_resp(400, "Bad POST input",
+                                        "format must be one of: pdf, csv, markdown")
+
+        perms = input.get("permissions") or dbio.ACLs.OWN
+        recs = self._sort_and_format_records(self._select_records_by_ids(ids, perms))
+        if not recs:
+            return self.send_error_resp(400, "Cannot export empty result set",
+                                        "No records match the specified IDs")
+
+        return self._format_records_as(recs, fmt)
 
     def create_record(self, newdata: Mapping):
         """

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -820,13 +820,24 @@ class ProjectSelectionHandler(ProjectRecordHandler):
     def export_selected_records(self, input: Mapping):
         """
         export records identified by IDs provided in the request body.
-        Expects: {"ids": ["id1", "id2", ...], "format": "pdf"|"csv"|"markdown"}
+        Expects: {"ids": ["id1", "id2", ...], "format": "json"|"pdf"|"csv"|"markdown"}
+        When format is omitted or "json", returns the records as a JSON array.
         """
         ids = input.get("ids", [])
         if not ids:
             return self.send_error_resp(400, "Bad POST input", "No record IDs provided")
 
-        fmt_name = input.get("format", "")
+        fmt_name = (input.get("format") or "json").strip().lower()
+        perms = input.get("permissions") or dbio.ACLs.OWN
+
+        recs = self._sort_and_format_records(self._select_records(perms, id=ids))
+        if not recs:
+            return self.send_error_resp(400, "Cannot export empty result set",
+                                        "No records match the specified IDs")
+
+        if fmt_name == "json":
+            return self.send_json(recs)
+
         supp_fmts = FormatSupport()
         supp_fmts.support(Format("pdf", "application/pdf"))
         supp_fmts.support(Format("markdown", "text/markdown"))
@@ -834,13 +845,7 @@ class ProjectSelectionHandler(ProjectRecordHandler):
         fmt = supp_fmts.match(fmt_name)
         if not fmt:
             return self.send_error_resp(400, "Bad POST input",
-                                        "format must be one of: pdf, csv, markdown")
-
-        perms = input.get("permissions") or dbio.ACLs.OWN
-        recs = self._sort_and_format_records(self._select_records(perms, id=ids))
-        if not recs:
-            return self.send_error_resp(400, "Cannot export empty result set",
-                                        "No records match the specified IDs")
+                                        "format must be one of: json, pdf, csv, markdown")
 
         return self._format_records_as(recs, fmt)
 

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -837,7 +837,7 @@ class ProjectSelectionHandler(ProjectRecordHandler):
                                         "format must be one of: pdf, csv, markdown")
 
         perms = input.get("permissions") or dbio.ACLs.OWN
-        recs = self._sort_and_format_records(self._select_records_by_ids(ids, perms))
+        recs = self._sort_and_format_records(self._select_records(perms, id=ids))
         if not recs:
             return self.send_error_resp(400, "Cannot export empty result set",
                                         "No records match the specified IDs")

--- a/python/tests/nistoar/midas/dbio/wsgi/test_project.py
+++ b/python/tests/nistoar/midas/dbio/wsgi/test_project.py
@@ -704,17 +704,38 @@ class TestMIDASProjectApp(test.TestCase):
         body = hdlr.handle()
         self.assertIn("400 ", self.resp[0])
 
-    def test_export_post_missing_format(self):
-        """POST /:export with no format field returns 400"""
+    def test_export_post_json_format(self):
+        """POST /:export with format=json returns 200 with a JSON array"""
+        prec = self.create_record("json_export")
         path = ":export"
         req = {
             'REQUEST_METHOD': 'POST',
             'PATH_INFO': self.rootpath + path
         }
-        req['wsgi.input'] = StringIO(json.dumps({"ids": ["mdm1:0001"]}))
+        req['wsgi.input'] = StringIO(json.dumps({"ids": [prec.id], "format": "json"}))
         hdlr = self.app.create_handler(req, self.start, path, nistr)
         body = hdlr.handle()
-        self.assertIn("400 ", self.resp[0])
+        self.assertIn("200 ", self.resp[0])
+        result = self.body2dict(body)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], prec.id)
+
+    def test_export_post_missing_format(self):
+        """POST /:export with no format field defaults to JSON and returns 200"""
+        prec = self.create_record("default_fmt")
+        path = ":export"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path
+        }
+        req['wsgi.input'] = StringIO(json.dumps({"ids": [prec.id]}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        body = hdlr.handle()
+        self.assertIn("200 ", self.resp[0])
+        result = self.body2dict(body)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
 
     def test_export_post_invalid_format(self):
         """POST /:export with unsupported format returns 400"""

--- a/python/tests/nistoar/midas/dbio/wsgi/test_project.py
+++ b/python/tests/nistoar/midas/dbio/wsgi/test_project.py
@@ -589,6 +589,145 @@ class TestMIDASProjectApp(test.TestCase):
                     self.assertTrue(pdf_content.startswith(b'%PDF'))
                     self.assertEqual(pdf_content, b"%PDF-1.4\ncombined pdf content")
 
+    def test_export_post_multiple_pdf(self):
+        """POST /:export with multiple IDs returns combined PDF"""
+        record_ids = []
+        for name in ["Post One", "Post Two"]:
+            path = ""
+            req = {
+                'REQUEST_METHOD': 'POST',
+                'PATH_INFO': self.rootpath + path
+            }
+            req['wsgi.input'] = StringIO(json.dumps({
+                "name": f"Export {name}",
+                "data": {"title": name}
+            }))
+            hdlr = self.app.create_handler(req, self.start, path, nistr)
+            body = hdlr.handle()
+            self.assertIn("201 ", self.resp[0])
+            record_ids.append(self.body2dict(body)['id'])
+            self.resp = []
+
+        with patch("nistoar.midas.export.exporters.pdf_exporter.trml2pdf.parseString",
+                   return_value=b"%PDF-1.4\npost export content"):
+            with patch("nistoar.midas.export.exporters.pdf_exporter.preppy.getModule") as mock_preppy:
+                mock_template = Mock()
+                mock_template.get.return_value = "<document>Post Export</document>"
+                mock_preppy.return_value = mock_template
+
+                def fake_pdf_concat(results, output_filename):
+                    return {
+                        "format": "pdf",
+                        "filename": "export.pdf",
+                        "mimetype": "application/pdf",
+                        "file_extension": ".pdf",
+                        "bytes": b"%PDF-1.4\npost export content",
+                    }
+
+                with patch.dict('nistoar.midas.export.export.CONCAT_REGISTRY', {"pdf": fake_pdf_concat}):
+                    path = ":export"
+                    req = {
+                        'REQUEST_METHOD': 'POST',
+                        'PATH_INFO': self.rootpath + path
+                    }
+                    req['wsgi.input'] = StringIO(json.dumps({
+                        "ids": record_ids,
+                        "format": "pdf"
+                    }))
+
+                    hdlr = self.app.create_handler(req, self.start, path, nistr)
+                    body = hdlr.handle()
+
+                    self.assertIn("200 ", self.resp[0])
+                    content_type = next((h for h in self.resp if h.startswith('Content-Type:')), None)
+                    self.assertIsNotNone(content_type)
+                    self.assertIn('application/pdf', content_type)
+
+                    pdf_content = b''.join(body) if isinstance(body, list) else body
+                    self.assertTrue(pdf_content.startswith(b'%PDF'))
+
+    def test_export_post_single_pdf(self):
+        """POST /:export with a single ID returns a valid PDF"""
+        path = ""
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path
+        }
+        req['wsgi.input'] = StringIO(json.dumps({"name": "Single Post", "data": {"title": "Single"}}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        body = hdlr.handle()
+        self.assertIn("201 ", self.resp[0])
+        record_id = self.body2dict(body)['id']
+        self.resp = []
+
+        with patch("nistoar.midas.export.exporters.pdf_exporter.trml2pdf.parseString",
+                   return_value=b"%PDF-1.4\nsingle post content"):
+            with patch("nistoar.midas.export.exporters.pdf_exporter.preppy.getModule") as mock_preppy:
+                mock_template = Mock()
+                mock_template.get.return_value = "<document>Single</document>"
+                mock_preppy.return_value = mock_template
+
+                def fake_pdf_concat(results, output_filename):
+                    return {
+                        "format": "pdf",
+                        "filename": "export.pdf",
+                        "mimetype": "application/pdf",
+                        "file_extension": ".pdf",
+                        "bytes": b"%PDF-1.4\nsingle post content",
+                    }
+
+                with patch.dict('nistoar.midas.export.export.CONCAT_REGISTRY', {"pdf": fake_pdf_concat}):
+                    path = ":export"
+                    req = {
+                        'REQUEST_METHOD': 'POST',
+                        'PATH_INFO': self.rootpath + path
+                    }
+                    req['wsgi.input'] = StringIO(json.dumps({"ids": [record_id], "format": "pdf"}))
+                    hdlr = self.app.create_handler(req, self.start, path, nistr)
+                    body = hdlr.handle()
+
+                    self.assertIn("200 ", self.resp[0])
+                    content_type = next((h for h in self.resp if h.startswith('Content-Type:')), None)
+                    self.assertIn('application/pdf', content_type)
+                    pdf_content = b''.join(body) if isinstance(body, list) else body
+                    self.assertTrue(pdf_content.startswith(b'%PDF'))
+
+    def test_export_post_empty_ids(self):
+        """POST /:export with empty ids returns 400"""
+        path = ":export"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path
+        }
+        req['wsgi.input'] = StringIO(json.dumps({"ids": [], "format": "pdf"}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        body = hdlr.handle()
+        self.assertIn("400 ", self.resp[0])
+
+    def test_export_post_missing_format(self):
+        """POST /:export with no format field returns 400"""
+        path = ":export"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path
+        }
+        req['wsgi.input'] = StringIO(json.dumps({"ids": ["mdm1:0001"]}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        body = hdlr.handle()
+        self.assertIn("400 ", self.resp[0])
+
+    def test_export_post_invalid_format(self):
+        """POST /:export with unsupported format returns 400"""
+        path = ":export"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path
+        }
+        req['wsgi.input'] = StringIO(json.dumps({"ids": ["mdm1:0001"], "format": "docx"}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        body = hdlr.handle()
+        self.assertIn("400 ", self.resp[0])
+
     def test_get_name(self):
         path = "mdm1:0003/name"
         req = {

--- a/python/tests/nistoar/midas/dbio/wsgi/test_project_midas.py
+++ b/python/tests/nistoar/midas/dbio/wsgi/test_project_midas.py
@@ -474,7 +474,7 @@ class TestMIDASProjectAppMongo(test.TestCase):
                     self.assertEqual(pdf_content, b"%PDF-1.4\nmongo combined content")
         
         self.resp = []
-        
+
         req = {
             'REQUEST_METHOD': 'GET',
             'PATH_INFO': self.rootpath + path
@@ -487,12 +487,79 @@ class TestMIDASProjectAppMongo(test.TestCase):
         self.assertIn('application/json', ctype[0])
         results = self.body2dict(body)
         self.assertEqual(len(results), 2)
-        
+
+    def test_export_post_pdf(self):
+        """POST /:export with multiple IDs returns combined PDF (MongoDB-backed)"""
+        record_ids = []
+        for name in ["Mongo Post One", "Mongo Post Two"]:
+            path = ""
+            req = {
+                'REQUEST_METHOD': 'POST',
+                'PATH_INFO': self.rootpath + path
+            }
+            req['wsgi.input'] = StringIO(json.dumps({"name": f"Export {name}", "data": {"title": name}}))
+            hdlr = self.app.create_handler(req, self.start, path, nistr)
+            body = hdlr.handle()
+            self.assertIn("201 ", self.resp[0])
+            record_ids.append(self.body2dict(body)['id'])
+            self.resp = []
+
+        with patch("nistoar.midas.export.exporters.pdf_exporter.trml2pdf.parseString",
+                   return_value=b"%PDF-1.4\nmongo post content"):
+            with patch("nistoar.midas.export.exporters.pdf_exporter.preppy.getModule") as mock_preppy:
+                mock_template = Mock()
+                mock_template.get.return_value = "<document>Mongo Post</document>"
+                mock_preppy.return_value = mock_template
+
+                def fake_pdf_concat(results, output_filename):
+                    return {
+                        "format": "pdf",
+                        "filename": "export.pdf",
+                        "mimetype": "application/pdf",
+                        "file_extension": ".pdf",
+                        "bytes": b"%PDF-1.4\nmongo post content",
+                    }
+
+                with patch.dict('nistoar.midas.export.export.CONCAT_REGISTRY', {"pdf": fake_pdf_concat}):
+                    path = ":export"
+                    req = {
+                        'REQUEST_METHOD': 'POST',
+                        'PATH_INFO': self.rootpath + path
+                    }
+                    req['wsgi.input'] = StringIO(json.dumps({"ids": record_ids, "format": "pdf"}))
+                    hdlr = self.app.create_handler(req, self.start, path, nistr)
+                    body = hdlr.handle()
+
+                    self.assertIn("200 ", self.resp[0])
+                    content_type = next((h for h in self.resp if h.startswith('Content-Type:')), None)
+                    self.assertIn('application/pdf', content_type)
+                    pdf_content = b''.join(body) if isinstance(body, list) else body
+                    self.assertTrue(pdf_content.startswith(b'%PDF'))
+
+    def test_export_post_empty_ids(self):
+        """POST /:export with empty ids returns 400 (MongoDB-backed)"""
+        path = ":export"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path
+        }
+        req['wsgi.input'] = StringIO(json.dumps({"ids": [], "format": "pdf"}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        body = hdlr.handle()
+        self.assertIn("400 ", self.resp[0])
+
+    def test_export_post_missing_format(self):
+        """POST /:export with no format field returns 400 (MongoDB-backed)"""
+        path = ":export"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path
+        }
+        req['wsgi.input'] = StringIO(json.dumps({"ids": ["mdm1:0001"]}))
+        hdlr = self.app.create_handler(req, self.start, path, nistr)
+        body = hdlr.handle()
+        self.assertIn("400 ", self.resp[0])
 
 
-
-                         
 if __name__ == '__main__':
     test.main()
-        
-        


### PR DESCRIPTION
Adds `POST /:export` as an alternative to `GET /?id=...&format=pdf` for exporting records to PDF, CSV, or Markdown.
The GET interface puts all record IDs in the query string. For large batches this overflows URL character limits (~2000 chars in browsers), making bulk exports fail silently or return a 414. 
Follows the same pattern as the existing `POST /:selected` sub-resource. The new endpoint accepts a JSON body:

Has to be tested in OAR-Docker using this branch and feat/export_get_to_post for portal
