### PR TITLE
Generalized support of for record review and integration with NPS

### DIFF
--- a/docker/midasserver/midas-dmpdap_conf.yml
+++ b/docker/midasserver/midas-dmpdap_conf.yml
@@ -51,6 +51,10 @@ services:
             nerdstorage:
               type: fsbased
               store_dir: /data/midas/nerdm
+            external_review:
+              name: simulated
+              as_system: nps1
+            reviewer_ids: [ "npsop" ]
 
    dmp: 
       about: 

--- a/docker/midasserver/midas-dmpdapnsd_conf.yml
+++ b/docker/midasserver/midas-dmpdapnsd_conf.yml
@@ -52,6 +52,8 @@ services:
             nerdstorage:
               type: fsbased
               store_dir: /data/midas/nerdm
+            external_review:
+              name: sim
 
    dmp: 
       about: 

--- a/etc/midasadm_conf.yml
+++ b/etc/midasadm_conf.yml
@@ -10,6 +10,9 @@ doi_naan: '10.88434'
 cmd:
 
   dap:
+    convention: mds3
+    nerdstorage:
+      type: mongo
     cmd:
 
       regpub:

--- a/python/nistoar/midas/cli/midasadm.py
+++ b/python/nistoar/midas/cli/midasadm.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         logging.getLogger(f"{prog} {ex.cmd}").critical("Config error: "+str(ex))
         sys.exit(4)
     except Exception as ex:
-        logging.getLogger(f"{prog} {ex.cmd}").exception(ex)
+        logging.getLogger(f"{prog}").exception(ex)
         sys.exit(200)
 
 

--- a/python/nistoar/midas/cli/midasadm.py
+++ b/python/nistoar/midas/cli/midasadm.py
@@ -26,6 +26,47 @@ epilog = None
 default_prog_name = "midasadm"
 default_conf_file = os.path.join(def_etc_dir, "midasadm_conf.yml")
 
+class MidasadmSuite(cli.CLISuite):
+    """
+    a :py:class:`~nistoar.pdr.utils.cli.CLISuite` specialized for the midasadm command
+
+    This implementation allows a sub-command's configuration to be extracted from the midas web 
+    service configuration to ensure to ensure a matching behavior of underlying functions.
+    """
+    config_svc_app_name = "midas-dbio"   # to get identical behavior to the web service version
+
+    def extract_config_for_cmd(self, config, cmdname, cmd=None):
+        """
+        extract the subcommand-specific configuration from the configuration provided.  
+
+        This specialization supports two schemas for the incoming configuration: the normal command 
+        schema supported by the general :py:mod:`cli module <nistoar.pdr.utils.cli>` and the midas-dbio 
+        web service configuration.  The latter ensures the configuration provide to select 
+        subcommands--and, thus, their behavior--will match that of midas-dbio web service.  If the given
+        ``config`` parameter dictionary contains a top-level ``cmd`` property, the standard cli module 
+        command-based schema (where ``cmd`` holds a dictionary where keys are the sub-command names) is 
+        assumed.  If the configuration contains a ``services`` property and the requested command 
+        (``cmdname``) matches one of its sub-properties, the midas-dbio service configuration schemea 
+        is assumed.  If neither property appears, the input configuration will be returned unchanged.  
+
+        :param dict config:  the configuration to extract the specific command configuration from
+        :param str cmdname:  the name of the command to look for
+        :param module  cmd:  the module where command's implementation is defined.  
+        """
+        if 'cmd' in config:
+            # interpret configuration by the standard cli convention
+            return super().extract_config_for_cmd(config, cmdname, cmd)
+
+        if config.get('services', {}).get(cmdname):
+            out = deepcopy(config)
+            del out['services']
+            cfg = config['services'][cmdname]
+            cfgmod.merge_config(cfg, out)
+            return out
+
+        return config
+            
+
 def main(cmdname, args):
     """
     a function that executes the ``midasadm`` command-line tool.  
@@ -34,7 +75,7 @@ def main(cmdname, args):
         cmdname = default_prog_name
 
     argparser = cli.define_prog_opts(cmdname, description, epilog)
-    midas = cli.CLISuite(cmdname, default_conf_file, argparser)
+    midas = MidasadmSuite(cmdname, default_conf_file, argparser)
 
     midas.load_subcommand(dap)
     # midas.load_subcommand(dmp)

--- a/python/nistoar/midas/dap/cmd/__init__.py
+++ b/python/nistoar/midas/dap/cmd/__init__.py
@@ -12,6 +12,7 @@ include
   - ``get``:      retrieve and display DAP records in JSON format
   - ``setstate``: update the state of a DAP record
   - ``revreq``:   request a review of an external reviewer system
+  - ``unsubmit``: pull a record submitted for review back to an editable state
   - ``review``:   submit feedback to a DAP record on behalf of an external reviewer
 """
 import os, argparse, logging
@@ -132,7 +133,7 @@ def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_c
     :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
                                                 interface into it 
     """
-    from . import regpub, setstate, review, revreq, get
+    from . import regpub, setstate, review, revreq, get, unsubmit
 
     subparser.description = description
     p = subparser
@@ -147,6 +148,7 @@ def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_c
     out.load_subcommand(get)
     out.load_subcommand(setstate)
     out.load_subcommand(revreq)
+    out.load_subcommand(unsubmit)
     out.load_subcommand(review)
 
     return out

--- a/python/nistoar/midas/dap/cmd/__init__.py
+++ b/python/nistoar/midas/dap/cmd/__init__.py
@@ -9,6 +9,7 @@ This module defines a set of subcommands to a command called (by default) "dap".
 include
   - ``regpub``:   register a previously published DAP into the DBIO
   - ``prepupd``:  prepare a previously published DAP for editing
+  - ``get``:      retrieve and display DAP records in JSON format
   - ``setstate``: update the state of a DAP record
   - ``revreq``:   request a review of an external reviewer system
   - ``review``:   submit feedback to a DAP record on behalf of an external reviewer
@@ -18,11 +19,13 @@ from collections.abc import Mapping
 from logging import Logger
 from importlib import import_module
 from argparse import ArgumentParser
+from copy import deepcopy
 
 from nistoar.pdr.utils import cli
 from nistoar.pdr.utils.prov import Agent
 from nistoar.midas.cli import get_agent
 from nistoar.base.config import ConfigurationException
+from nistoar.base import config as cfgmod
 from nistoar.midas.dap.nerdstore import NERDResourceStorageFactory
 from nistoar.midas.dbio import FSBasedDBClientFactory, MongoDBClientFactory, InMemoryDBClientFactory
 
@@ -86,7 +89,7 @@ class DAPCmd(cli.CommandSuite):
             # interpret configuration by the standard cli convention
             return super().extract_config_for_cmd(config, cmdname, cmd)
 
-        if not cfg.get('conventions'):
+        if not config.get('conventions'):
             return config
 
         out = deepcopy(config)
@@ -97,7 +100,7 @@ class DAPCmd(cli.CommandSuite):
         if not convention and os.environ.get('OAR_DAP_CONVENTION'):
             convention = os.environ['OAR_DAP_CONVENTION']
         if not convention:
-            convention = cfg.get('default_convention')
+            convention = config.get('default_convention')
         if not convention:
             convs = list(config['conventions'].keys())
             if len(convs) == 1:
@@ -129,7 +132,7 @@ def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_c
     :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
                                                 interface into it 
     """
-    from . import regpub, setstate, review, revreq
+    from . import regpub, setstate, review, revreq, get
 
     subparser.description = description
     p = subparser
@@ -141,8 +144,9 @@ def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_c
         as_cmd = default_name
     out = DAPCmd(as_cmd, subparser)
     out.load_subcommand(regpub)
+    out.load_subcommand(get)
     out.load_subcommand(setstate)
-#    out.load_subcommand(revreq)
+    out.load_subcommand(revreq)
     out.load_subcommand(review)
 
     return out

--- a/python/nistoar/midas/dap/cmd/__init__.py
+++ b/python/nistoar/midas/dap/cmd/__init__.py
@@ -134,7 +134,7 @@ def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_c
     :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
                                                 interface into it 
     """
-    from . import regpub, setstate, review, revreq, get, unsubmit
+    from . import regpub, setstate, review, revreq, get, unsubmit, revperm
 
     subparser.description = description
     p = subparser
@@ -150,6 +150,7 @@ def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_c
     out.load_subcommand(setstate)
     out.load_subcommand(revreq)
     out.load_subcommand(unsubmit)
+    out.load_subcommand(revperm)
     out.load_subcommand(review)
 
     return out

--- a/python/nistoar/midas/dap/cmd/__init__.py
+++ b/python/nistoar/midas/dap/cmd/__init__.py
@@ -13,6 +13,7 @@ include
   - ``setstate``: update the state of a DAP record
   - ``revreq``:   request a review of an external reviewer system
   - ``unsubmit``: pull a record submitted for review back to an editable state
+  - ``revperm``:  set or unset a record's permissions for review.
   - ``review``:   submit feedback to a DAP record on behalf of an external reviewer
 """
 import os, argparse, logging

--- a/python/nistoar/midas/dap/cmd/__init__.py
+++ b/python/nistoar/midas/dap/cmd/__init__.py
@@ -10,12 +10,14 @@ include
   - ``regpub``:   register a previously published DAP into the DBIO
   - ``prepupd``:  prepare a previously published DAP for editing
   - ``setstate``: update the state of a DAP record
+  - ``revreq``:   request a review of an external reviewer system
   - ``review``:   submit feedback to a DAP record on behalf of an external reviewer
 """
-import os, argparse
+import os, argparse, logging
 from collections.abc import Mapping
 from logging import Logger
 from importlib import import_module
+from argparse import ArgumentParser
 
 from nistoar.pdr.utils import cli
 from nistoar.pdr.utils.prov import Agent
@@ -27,7 +29,99 @@ from nistoar.midas.dbio import FSBasedDBClientFactory, MongoDBClientFactory, InM
 default_name = "dap"
 help = "manage dap records via subcommands"
 description = \
-"""apply an action to a DAP record"""
+"""apply an action to a DAP record
+
+The configuration provided to this command can include a conventions property for configuring 
+for multiple DAP processing conventions in the same fashion as the midas-dbio web service.  When 
+provided, each subproperty will be the name of a supported convention, and its value will be the 
+specific configuration.  The convention is chosen by its name given in one of the following ways, 
+in this priority:
+  1. the convention name provided by the --convention option,
+  2. if set, the value of the OAR_DAP_CONVENTION environment variable,
+  3. The default_convention property in the provided configuration (when the midas-dbio schema 
+     is used; see midasadm -h for more details), 
+  4. The loan convention configured when only one convention is provided.
+"""
+
+class DAPCmd(cli.CommandSuite):
+    """
+    a :py:class:`~nistoar.pdr.utils.cli.CommandSuite` specialized for the ``dap`` subcommand.
+
+    This implementation allows the command's configuration to be extracted from the midas web 
+    service configuration to ensure to ensure a matching behavior of underlying functions.
+    """
+    def __init__(self, suitename: str, parent_parser: ArgumentParser, current_dests=None,
+                 def_convention: str=None):
+        super(DAPCmd, self).__init__(suitename, parent_parser, current_dests)
+        self._useconv = def_convention
+
+    def extract_config_for_cmd(self, config, cmdname, cmd=None, convention=None):
+        """
+        extract the dap command-specific configuration from the configuration provided.  
+
+        This specialization supports two schemas for the incoming configuration: the normal command 
+        schema supported by the general :py:mod:`cli module <nistoar.pdr.utils.cli>` and the 
+        midas-dbio schema provided via its ``services`` property.  The latter ensures the configuration 
+        provide to the ``dap`` subcommands--and, thus, their behavior--to match that of midas-dbio web 
+        service.  The standard cli module command-based schema will be assumed if the given configuration 
+        contains ``cmd`` property.  Otherwise, if the configuration contains the ``conventions`` property, 
+        the midas-dbio schema will be assumed.  If neither appears, the input configuration will be 
+        returned unchanged.  
+
+        :param dict config:  the configuration to extract the specific command configuration from
+        :param str cmdname:  the name of the command to look for
+        :param module  cmd:  the module where command's implementation is defined.  If provided and 
+                             ``cmdname`` is not found within the ``cmd`` property, the value of 
+                             ``default_name`` from the module will be looked for instead.  
+        :param str convention:  the name of the DAP processing convention (e.g. ``mds3``) to assume.
+                             This is used to pull out the configuration appropriate for that 
+                             convention when the configuration is using the midas-dbio schema (i.e.
+                             it includes a ``conventions`` property).  If not provided, then convention
+                             specified by the ``default_convention`` configuration property will be 
+                             assumed.  
+        :raises ConfigurationException: if ``convention`` is not specified and a default one cannot be 
+                             determined
+        """
+        if 'cmd' in config:
+            # interpret configuration by the standard cli convention
+            return super().extract_config_for_cmd(config, cmdname, cmd)
+
+        if not cfg.get('conventions'):
+            return config
+
+        out = deepcopy(config)
+        del out['conventions']
+
+        if not convention:
+            convention = self._useconv
+        if not convention and os.environ.get('OAR_DAP_CONVENTION'):
+            convention = os.environ['OAR_DAP_CONVENTION']
+        if not convention:
+            convention = cfg.get('default_convention')
+        if not convention:
+            convs = list(config['conventions'].keys())
+            if len(convs) == 1:
+                convention = convs[0]
+        if not convention:
+            raise ConfigurationException("Missing required parameter: services.dap.default_convention")
+        if not config['conventions'].get(convention):
+            raise ConfigurationException("Missing sub-configuration: " +
+                                         f"services.dap.conventions.{convention}")
+
+        out = cfgmod.merge_config(config['conventions'][convention], out)
+        out['convention'] = convention
+        return out
+
+    def execute(self, args, config: Mapping=None, log: logging.Logger=None):
+        """
+        execute a dap subcommand from this command suite
+        :param argparse.Namespace args:  the parsed arguments
+        :param dict             config:  the configuration to use
+        :param Logger              log:  the log to send messages to 
+        """
+        if args.conv:
+            self._useconv = args.conv
+        super().execute(args, config, log)
 
 def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_cmd: str=None):
     """
@@ -35,15 +129,20 @@ def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_c
     :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
                                                 interface into it 
     """
-    from . import regpub, setstate, review
+    from . import regpub, setstate, review, revreq
 
     subparser.description = description
+    p = subparser
+    p.add_argument("-C", "--convention", "--conv", metavar="NAME", type=str, dest='conv',
+                   help="a label identifying the DAP processing convention to assume when "+
+                        "executing a dap command")
 
     if not as_cmd:
         as_cmd = default_name
-    out = cli.CommandSuite(as_cmd, subparser)
+    out = DAPCmd(as_cmd, subparser)
     out.load_subcommand(regpub)
     out.load_subcommand(setstate)
+#    out.load_subcommand(revreq)
     out.load_subcommand(review)
 
     return out

--- a/python/nistoar/midas/dap/cmd/get.py
+++ b/python/nistoar/midas/dap/cmd/get.py
@@ -1,0 +1,139 @@
+"""
+CLI command that pulls DAP records or portions thereof and sends to standard out
+"""
+import logging, argparse, os, sys, json
+from logging import Logger
+from copy import deepcopy
+from pathlib import Path
+from collections.abc import Mapping
+from collections import OrderedDict
+
+from nistoar.base.config import ConfigurationException
+from nistoar.midas import MIDASException
+from nistoar.pdr.utils.cli import CommandFailure, explain
+from nistoar.pdr.utils.prov import Agent, Action
+from nistoar.midas.dbio import (FSBasedDBClientFactory, MongoDBClientFactory, InMemoryDBClientFactory,
+                                NotEditable, NotAuthorized, AlreadyExists, ObjectNotFound, ACLs,
+                                status, PUBLIC_GROUP)
+from nistoar.midas.dap.extrev import ExternalReviewException
+from nistoar.pdr import constants as const
+
+from . import create_DAPService, get_agent
+
+default_name = "get"
+help = "Return DAP record data"
+description = \
+"""Pull a draft DAP record from the MIDAS database and display its contents in JSON format.  Portions 
+of the record can be displayed by specifying a top-level property.  Note that if no property is specify
+the returned DAP record's data property will be a summary version of the data content; if the data 
+property is specified, the full NERDm data will be returned (unless --data-summary is also specified).
+"""
+
+def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_cmd: str=None):
+    """
+    load this command into a CLI by defining the command's arguments and options.
+    :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
+                                                interface into it 
+    :param list current_dests:  a list of destination names for parameters that have already been 
+                                defined
+    :param str as_cmd:  the subcommand name assigned to the action provided by this module
+    :rtype: None
+    """
+    p = subparser
+    p.description = description
+    p.cmd = as_cmd
+    p.add_argument("dbid", metavar="DBID", type=str, 
+                   help="the DBIO identifier of the DAP to submit for review")
+    p.add_argument("prop", metavar="PROPERTY", type=str, nargs='?', default=[],
+                   help="restrict the output to the value of the DBIO record property from "+
+                        "the DAP record.  Example values include 'data' and 'status'")
+    p.add_argument("-o", "--output", metavar="FILE", type=str, dest="outfile",
+                   help="write the output to a file with the specified name.  If the file already "+
+                        "already exists, it will be overwritten")
+    p.add_argument("-s", "--data-summary", action="store_true", dest="dosumm",
+                   help="if the data property is requested, return the summarized version.  This will "+
+                        "summary will leave out, for example, the full list of NERDm components.")
+
+    return None
+
+def execute(args, config: Mapping=None, log: Logger=None):
+    """
+    execute this command: retrieve and display the DAP record
+    """
+    if not log:
+        log = logging.getLogger(default_name)
+    if not config:
+        config = {}
+
+    if isinstance(args, list):
+        # cmd-line arguments not parsed yet
+        p = argparse.ArgumentParser()
+        load_command(p)
+        args = p.parse_args(args)
+
+    if not args.dbid:
+        raise CommandFailure(args.cmd, "DAP ID not specified", 2)
+    if args.prop and not isinstance(args.prop, list):
+        args.prop = [ args.prop ]
+    
+    agent = get_agent(args, config)
+    try:
+        svc = create_DAPService(agent, args, config, log)
+    except ConfigurationException as ex:
+        raise CommandFailure(args.cmd, "Config error: "+str(ex), 6) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, "Unable to create DAP service: "+str(ex), 1) from ex
+
+    out = None
+    try:
+        prec = svc.get_record(args.dbid)
+    except ObjectNotFound as ex:
+        raise CommandFailure(args.cmd, f"{args.dbid}: DAP not found ({str(ex)})", 1) from ex        
+    except NotAuthorized as ex:
+        raise CommandFailure(args.cmd, f"Unexpected authorization failure: {str(ex)}", 9) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, f"Unexpected failure: {str(ex)}", 1) from ex
+
+    out = prec.to_dict()
+    if len(args.prop) > 0:
+        if args.prop[0] == "data" and not args.dosumm:
+            try:
+                out = svc.get_nerdm_data(args.dbid)
+            except Exception as ex:
+                log.exception(ex)
+                raise CommandFailure(args.cmd,
+                                     f"Unexpected failure getting full data: {str(ex)}", 1) from ex
+        else:
+            out = out.get(args.prop[0])
+            if out == None:
+                raise CommandFailure(args.cmd, f"{args.dbid}: {prop[0]} not found", 1) from ex
+
+    ostrm = sys.stdout
+    try:
+        if args.outfile:
+            ostrm = None
+            ostrm = open(args.outfile, 'w')
+        json.dump(out, ostrm, indent=2)
+    except FileNotFoundError as ex:
+        raise CommandFailure(args.cmd, f"{args.outfile}: {str(ex)}", 4)
+    except IOError as ex:
+        raise CommandFailure(args.cmd, f"{args.dbid}: trouble writing output: {str(ex)}", 4)
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, f"{args.dbid}: Unexpected failure: {str(ex)}", 1) from ex
+    finally:
+        if args.outfile and ostrm:
+            try:
+                ostrm.close()
+            except Exception as ex:
+                log.warning("Trouble closing output file: str(ex)")
+
+
+                
+
+    
+
+    
+            

--- a/python/nistoar/midas/dap/cmd/review.py
+++ b/python/nistoar/midas/dap/cmd/review.py
@@ -126,6 +126,8 @@ def execute(args, config: Mapping=None, log: Logger=None):
             svc.apply_external_review(args.dbid, args.revsys, args.phase, args.revid,
                                       args.infourl, feedback, args.change, args.replace)
 
+    except ObjectNotFound as ex:
+        raise CommandFailure(args.cmd, f"{args.dsid}: DAP not found ({str(ex)})", 1) from ex        
     except NotAuthorized as ex:
         raise CommandFailure(args.cmd, f"Unexpected authorization failure: {str(ex)}", 9) from ex
     except Exception as ex:

--- a/python/nistoar/midas/dap/cmd/review.py
+++ b/python/nistoar/midas/dap/cmd/review.py
@@ -100,9 +100,9 @@ def execute(args, config: Mapping=None, log: Logger=None):
         raise CommandFailure(args.cmd, "Unable to create DAP service: "+str(ex), 1) from ex
 
     try:
-        if args.phase == "approve":
+        if args.phase == "approved" or args.phase == "approve":
             if args.feedback:
-                log.warning("feedback statements ignored for phase=approve")
+                log.warning("feedback statements ignored for phase=approved")
             svc.approve(args.dbid, args.revsys, args.revid, args.infourl) 
 
         elif args.phase == "cancel":

--- a/python/nistoar/midas/dap/cmd/revperm.py
+++ b/python/nistoar/midas/dap/cmd/revperm.py
@@ -1,0 +1,115 @@
+"""
+CLI command that switches the permissions on a DAP record to and from review mode
+"""
+import logging, argparse, os, sys, json
+from logging import Logger
+from copy import deepcopy
+from pathlib import Path
+from collections.abc import Mapping
+from collections import OrderedDict
+
+from nistoar.base.config import ConfigurationException
+from nistoar.midas import MIDASException
+from nistoar.pdr.utils.cli import CommandFailure, explain
+from nistoar.pdr.utils.prov import Agent, Action
+from nistoar.midas.dbio import (FSBasedDBClientFactory, MongoDBClientFactory, InMemoryDBClientFactory,
+                                NotEditable, NotAuthorized, AlreadyExists, ObjectNotFound, ACLs,
+                                status, PUBLIC_GROUP)
+from nistoar.midas.dap.extrev import ExternalReviewException
+from nistoar.pdr import constants as const
+
+from . import create_DAPService, get_agent
+
+default_name = "revperm"
+help = "switch a DAP record's permissions to and from review mode"
+description = \
+"""Change the permissions on a DAP record to and from those needed for external review.  During 
+external review, the permissions to update or manage a DAP record is temporarily taken away from the 
+owner and co-editors and given to over a special reviewer account.  In addition, that reviewer account
+is also given a special "publish" permission, allowing it to push the record to final publication once 
+external review is successful.  By default, this command switches permissions into the review state; 
+use --unset to revert them back for editing.  
+
+This command does not update the state or otherwise affect the state of review.  (See also the 
+dap command, unsubmit.)
+"""
+
+def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_cmd: str=None):
+    """
+    load this command into a CLI by defining the command's arguments and options.
+    :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
+                                                interface into it 
+    :param list current_dests:  a list of destination names for parameters that have already been 
+                                defined
+    :param str as_cmd:  the subcommand name assigned to the action provided by this module
+    :rtype: None
+    """
+    p = subparser
+    p.description = description
+    p.cmd = as_cmd
+    p.add_argument("dbid", metavar="DBID", type=str, 
+                   help="the DBIO identifier of the DAP to submit for review")
+    p.add_argument("-U", "--unset", action="store_true", dest="unset",
+                   help="unset the review permissions (rather than setting them)")
+    p.add_argument("-u", "--unset-for-feedback", action="store_true", dest="for_review",
+                   help="unset the review permissions to allow response to review feedback")
+    p.add_argument("-r", "--reader", metavar="USERID", action="append", dest="readers", default=[],
+                   help="grant read access to each USERID provided.  While this option can be "+
+                        "used multiple times, multiple IDs can also be provided as a comma-delimited "+
+                        "list.  Ignored when used with -u or -U")
+
+    return None
+
+def execute(args, config: Mapping=None, log: Logger=None):
+    """
+    execute this command: set or unset the review permisisons
+    """
+    if not log:
+        log = logging.getLogger(default_name)
+    if not config:
+        config = {}
+
+    if isinstance(args, list):
+        # cmd-line arguments not parsed yet
+        p = argparse.ArgumentParser()
+        load_command(p)
+        args = p.parse_args(args)
+
+    if not args.dbid:
+        raise CommandFailure(args.cmd, "DAP ID not specified", 2)
+
+    if args.readers:
+        if args.unset or args.for_review:
+            log.warning("Unset requested; --reader values ignored.")
+        else:
+            for i in range(len(args.readers)):
+                args.readers.extend(args.readers.pop(0).split(','))
+
+    agent = get_agent(args, config)
+    try:
+        svc = create_DAPService(agent, args, config, log)
+    except ConfigurationException as ex:
+        raise CommandFailure(args.cmd, "Config error: "+str(ex), 6) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, "Unable to create DAP service: "+str(ex), 1) from ex
+
+    try:
+        prec = svc.get_record(args.dbid)
+
+        if args.unset or args.for_review:
+            svc._unset_review_permissions(prec, args.for_review)
+        else:
+            svc._set_review_permissions(prec, args.readers)
+
+        prec.save()
+
+    except ObjectNotFound as ex:
+        raise CommandFailure(args.cmd, f"{args.dbid}: DAP not found ({str(ex)})", 1) from ex        
+    except NotAuthorized as ex:
+        raise CommandFailure(args.cmd, f"Unexpected authorization failure: {str(ex)}", 9) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, f"Unexpected failure: {str(ex)}", 1) from ex
+
+

--- a/python/nistoar/midas/dap/cmd/revperm.py
+++ b/python/nistoar/midas/dap/cmd/revperm.py
@@ -78,8 +78,11 @@ def execute(args, config: Mapping=None, log: Logger=None):
     if not args.dbid:
         raise CommandFailure(args.cmd, "DAP ID not specified", 2)
 
+    if args.for_review:
+        args.unset = True
+
     if args.readers:
-        if args.unset or args.for_review:
+        if args.unset:
             log.warning("Unset requested; --reader values ignored.")
         else:
             for i in range(len(args.readers)):
@@ -97,7 +100,7 @@ def execute(args, config: Mapping=None, log: Logger=None):
     try:
         prec = svc.get_record(args.dbid)
 
-        if args.unset or args.for_review:
+        if args.unset:
             svc._unset_review_permissions(prec, args.for_review)
         else:
             svc._set_review_permissions(prec, args.readers)

--- a/python/nistoar/midas/dap/cmd/revreq.py
+++ b/python/nistoar/midas/dap/cmd/revreq.py
@@ -1,0 +1,177 @@
+"""
+CLI command that submits a DAP record for review and publication or some part of that process
+"""
+import logging, argparse, os, re
+from logging import Logger
+from copy import deepcopy
+from pathlib import Path
+from collections.abc import Mapping
+from collections import OrderedDict
+
+from nistoar.base.config import ConfigurationException
+from nistoar.midas import MIDASException
+from nistoar.pdr.utils.cli import CommandFailure, explain
+from nistoar.pdr.utils.prov import Agent, Action
+from nistoar.midas.dbio import (FSBasedDBClientFactory, MongoDBClientFactory, InMemoryDBClientFactory,
+                                NotEditable, NotAuthorized, AlreadyExists, ObjectNotFound, ACLs,
+                                status, PUBLIC_GROUP)
+from nistoar.midas.dap.extrev import ExternalReviewException
+from nistoar.pdr import constants as const
+
+from . import create_DAPService, get_agent
+
+default_name = "revreq"
+help = "Submit a DAP for review"
+description = \
+"""Submit a DAP for review to the configured external review system (at NIST, this is the NPS). The 
+DAP will then be able to accept feedback from the review system (which may eventually trigger 
+publication upon successful completion of the review). 
+
+This command will not attempt to validate or finalize the DAP nor alter the access permissions.  Often
+when this command is needed, these operations have already occurred.  If not, see the finalize and 
+revperms commands, or use the submit command to combine all of these operations into one call.  
+"""
+
+def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_cmd: str=None):
+    """
+    load this command into a CLI by defining the command's arguments and options.
+    :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
+                                                interface into it 
+    :param list current_dests:  a list of destination names for parameters that have already been 
+                                defined
+    :param str as_cmd:  the subcommand name assigned to the action provided by this module
+    :rtype: None
+    """
+    p = subparser
+    p.description = description
+    p.cmd = as_cmd
+    p.add_argument("dbid", metavar="DBID", type=str, 
+                   help="the DBIO identifier of the DAP to submit for review")
+    p.add_argument("-C", "--change", metavar="NAME", type=str, dest='changes', action='append',
+                   choices="newrec mdup mindata majdata newfile rmfile deact".split(),
+                   help="a label indicating a type of change that was made (during a revision), one "+
+                        "of  'newrec', 'mdup', 'mindata', 'majdata', 'newfile', 'rmfile', "+
+                        "or 'deact'.  Repeat this option as needed for multiple changes.")
+    p.add_argument("-s", "--software-review", action='store_true', dest='secrev', 
+                   help="indicate in the request that software is included in the publication so to "+
+                        "trigger a software security review.  If not provided, this will be determined "+
+                        "based on the DAP's state")
+    p.add_argument("-S", "--no-software-review", action='store_true', dest='nosecrev', 
+                   help="prevent triggering a software security review  If not provided, this will be "+
+                        "determined based on the DAP's state")
+    p.add_argument("-r", "--record-requested", action="store_true", dest='markreq',
+                   help="after requesting review, update the review status to indicate that review was "+
+                        "requested. This should happen by default if the review system is nps1")
+    p.add_argument("-i", "--instruction", metavar="MESSAGE", dest='instruct',
+                   help="a message to send as special instructions to the reviewers")
+    p.add_argument("--server", metavar="DNSNAME", type=str, dest='server',
+                   help="the NPS server to send the request to; this can be used to send the request "+
+                        "via the usual API but operating on a different (e.g. test) server.  If not "+
+                        "provided, this configured service endpoint will be used")
+    p.add_argument("-n", "--service-name", metavar="NAME", type=str, dest='sysname',
+                   help="request review by the named review system.  If not provided, the request will "+
+                        "be sent to the configured system")
+
+    return None
+
+def execute(args, config: Mapping=None, log: Logger=None):
+    """
+    execute this command: submit the DAP for review
+    """
+    if not log:
+        log = logging.getLogger(default_name)
+    if not config:
+        config = {}
+
+    if isinstance(args, list):
+        # cmd-line arguments not parsed yet
+        p = argparse.ArgumentParser()
+        load_command(p)
+        args = p.parse_args(args)
+
+    if args.secrev and args.nosecrev:
+        raise CommandFailure("-s and -S are incompatible", 2)
+
+    revcfg = config.get('external_review')
+    if not revcfg:
+        raise CommandFailure(args.cmd, "Config error: missing required property: external_review", 6)
+
+    if not args.dbid:
+        raise CommandFailure(args.cmd, "DAP ID not specified", 2)
+    if args.sysname:
+        revcfg['name'] = args.sysname
+    if args.server:
+        if revcfg.get('nps_endpoint'):
+            epre = re.compile(r'^(https?://)[^:/]+')
+            m = epre.search(revcfg['nps_endpoint'])
+            if m:
+                revcfg['nps_endpoint'] = epre.sub(m.group(1)+args.server, revcfg['nps_endpoint'])
+    
+    agent = get_agent(args, config)
+    try:
+        svc = create_DAPService(agent, args, config, log)
+    except ConfigurationException as ex:
+        raise CommandFailure(args.cmd, "Config error: "+str(ex), 6) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, "Unable to create DAP service: "+str(ex), 1) from ex
+
+    extrevcli = svc._extrevcli
+                        
+    try:
+        prec = svc.get_record(args.dbid)
+        version = prec.data.get('version') or prec.data.get('@version') or '1.0.0'
+
+        opts = { 'title': prec.data.get("title") }
+        opts['description'] = "\n\n".join(prec.data.get("description", []))
+        if ':' in args.dbid:
+            opts['pubid'] = "ark:/"+ const.ARK_NAAN + '/' + re.sub(r':', '-', args.dbid)
+        if args.instruct:
+            opts['instructions'] = args.instruct
+        if args.changes:
+            opts['changes'] = args.changes
+        else:
+            # TO DO: try to determine from state of the DAP.  Any new/updated files?
+            if re.match(r'^1(\.0)*$', version):
+                opts['changes'] = ['newrec']
+            else:
+                opts['changes'] = ['majdata']
+            
+        # TO DO: support reviewers
+
+        if args.secrev or (not args.nosecrev and prec.meta.get("software_included")):
+            opts['security_review'] = True
+
+        # now submit the review request
+        extrevcli.submit(args.dbid, agent.actor, version, **opts)
+
+    except ObjectNotFound as ex:
+        raise CommandFailure(args.cmd, f"{args.dbid}: DAP not found ({str(ex)})", 1) from ex        
+    except NotAuthorized as ex:
+        raise CommandFailure(args.cmd, f"Unexpected authorization failure: {str(ex)}", 9) from ex
+    except ExternalReviewException as ex:
+        raise CommandFailure(args.cmd,
+                             f"{extrevcli.system_name} review request failure: {str(ex)}", 1) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, f"Unexpected failure: {str(ex)}", 1) from ex
+
+    if args.markreq or extrevcli.system_name in ["nps1"]:
+       try:
+            # mark review as requested as the legacy NPS will not respond immediately
+            # need to do this before changing permissions
+            svc.apply_external_review(prec.id, extrevcli.system_name, "requested", _prec=prec)
+       except NotAuthorized as ex:
+           raise CommandFailure(args.cmd,
+                                f"Unexpected authorization failure during record update: {str(ex)}",
+                                9) from ex
+       except Exception as ex:
+           log.exception(ex)
+           raise CommandFailure(args.cmd,
+                                f"Unexpected failure during record update: {str(ex)}", 1) from ex
+
+        
+            
+
+            
+

--- a/python/nistoar/midas/dap/cmd/unsubmit.py
+++ b/python/nistoar/midas/dap/cmd/unsubmit.py
@@ -1,0 +1,136 @@
+"""
+CLI command resets a submitted to record to an editable state
+"""
+import logging, argparse, os, sys, json
+from logging import Logger
+from copy import deepcopy
+from pathlib import Path
+from collections.abc import Mapping
+from collections import OrderedDict
+
+from nistoar.base.config import ConfigurationException
+from nistoar.midas import MIDASException
+from nistoar.pdr.utils.cli import CommandFailure, explain
+from nistoar.pdr.utils.prov import Agent, Action
+from nistoar.midas.dbio import (FSBasedDBClientFactory, MongoDBClientFactory, InMemoryDBClientFactory,
+                                NotEditable, NotAuthorized, AlreadyExists, ObjectNotFound, ACLs,
+                                status, PUBLIC_GROUP)
+from nistoar.midas.dap.extrev import ExternalReviewException
+from nistoar.pdr import constants as const
+
+from . import create_DAPService, get_agent
+
+default_name = "unsubmit"
+help = "Return a submitted DAP record back to an editable state"
+description = \
+"""Return a submitted DAP record back to an editable state.  This is often done to allow an author 
+to respond to reviewer feedback or otherwise make changes in the middle of the review process;
+however, it can also be used to pull back a record that was submitted by mistake.  
+
+This command will reset the state to "edit" and re-establish the pre-submit permissions.  (See also 
+the dap commands setstate and revperm which do these two operations independently.)  The 
+-f or -F option can be used to erase the current status of the previously requested review.  
+"""
+
+def load_into(subparser: argparse.ArgumentParser, current_dests: list=None, as_cmd: str=None):
+    """
+    load this command into a CLI by defining the command's arguments and options.
+    :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
+                                                interface into it 
+    :param list current_dests:  a list of destination names for parameters that have already been 
+                                defined
+    :param str as_cmd:  the subcommand name assigned to the action provided by this module
+    :rtype: None
+    """
+    p = subparser
+    p.description = description
+    p.cmd = as_cmd
+    p.add_argument("dbid", metavar="DBID", type=str, 
+                   help="the DBIO identifier of the DAP to submit for review")
+    p.add_argument("-c", "--cancel-review", metavar='REVSYS', type=str, dest='cancel',
+                   help="mark the status of the review from the REVSYS review system as cancelled. "+
+                        "(Note: this does not attempt to communicate this to the external review " +
+                        "system; it only updates the local status)")
+    p.add_argument("-f", "--forget-review", metavar='REVSYS', type=str, dest='forget',
+                   help="clear the status of the review from the REVSYS review system, as if "+
+                        "it was never requested.  (Note: this does not attempt to communicate " +
+                        "with the review system; it only updates the local status).")
+    p.add_argument("-F", "--forget-all-reviews", action="store_true", dest='forgetall',
+                   help="clear the status of all reviews from the REVSYS review system, as if "+
+                        "they were never requested.  (Note: this does not attempt to communicate " +
+                        "with the review systems; it only updates the local status).")
+
+    return None
+
+def execute(args, config: Mapping=None, log: Logger=None):
+    """
+    execute this command: unsubmit the DAP from review
+    """
+    if not log:
+        log = logging.getLogger(default_name)
+    if not config:
+        config = {}
+
+    if isinstance(args, list):
+        # cmd-line arguments not parsed yet
+        p = argparse.ArgumentParser()
+        load_command(p)
+        args = p.parse_args(args)
+
+    if args.cancel and (args.forget or args.forgetall):
+        log.warning("Ignoring -c; overridden by -f or -F")
+
+    if not args.dbid:
+        raise CommandFailure(args.cmd, "DAP ID not specified", 2)
+
+    agent = get_agent(args, config)
+    try:
+        svc = create_DAPService(agent, args, config, log)
+    except ConfigurationException as ex:
+        raise CommandFailure(args.cmd, "Config error: "+str(ex), 6) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, "Unable to create DAP service: "+str(ex), 1) from ex
+
+    try:
+        prec = svc.get_record(args.dbid)
+
+        needsave = False
+        if args.cancel:
+            # this will also unset the permissions and set state back to EDIT (and save changes)
+            svc.cancel_external_review(args.dbid, args.cancel)
+            prec = svc.get_record(args.dbid)
+
+        else:
+            # restoring permissions
+            prec.status.set_state(status.EDIT)
+            for_review = not (args.forgetall or args.forget)
+            svc._unset_review_permissions(prec, for_review)
+            needsave = True
+
+        if args.forgetall:
+            systems = prec.status.get_review_systems()
+            if not systems:
+                log.warning("No review status found from any review system")
+            else:
+                for sys in systems:
+                    prec.status.delete_review_from(sys)
+                needsave = True
+
+        elif args.forget:
+            if not prec.status.delete_review_from(args.forget):
+                log.warning("No review status found for %s (not started yet?)", args.forget)
+            else:
+                needsave = True
+
+        if needsave:
+            prec.save()
+
+    except ObjectNotFound as ex:
+        raise CommandFailure(args.cmd, f"{args.dbid}: DAP not found ({str(ex)})", 1) from ex        
+    except NotAuthorized as ex:
+        raise CommandFailure(args.cmd, f"Unexpected authorization failure: {str(ex)}", 9) from ex
+    except Exception as ex:
+        log.exception(ex)
+        raise CommandFailure(args.cmd, f"Unexpected failure: {str(ex)}", 1) from ex
+

--- a/python/nistoar/midas/dap/extrev/base.py
+++ b/python/nistoar/midas/dap/extrev/base.py
@@ -11,7 +11,18 @@ class ExternalReviewException(MIDASException):
     """
     a base exception for issues when interacting with an external review system
     """
-    pass
+    def __init__(self, message: str, sysname: str=None, statuscode: int=None):
+        """
+        initialize the exception
+
+        :param str message:  the description of what caused the exception
+        :param str  system:  the name of the external review system being engaged
+        :param int statuscode:  the HTTP status code that the service responded with (when applicable)
+        """
+        super(ExternalReviewException, self).__init__(message)
+        self.system = sysname
+        self.status = statuscode
+
 
 class ExternalReviewClient(ABC):
     """

--- a/python/nistoar/midas/dap/extrev/base.py
+++ b/python/nistoar/midas/dap/extrev/base.py
@@ -2,6 +2,7 @@
 base and common classes for for managing external review clients
 """
 from abc import ABC, abstractmethod
+from typing import Mapping
 
 from nistoar.midas import MIDASException
 
@@ -37,12 +38,13 @@ class ExternalReviewClient(ABC):
         self.cfg = config or {}
 
     @abstractmethod
-    def submit(self, id: str, submitter: str, version: str=None, **options):
+    def submit(self, id: str, submitter: str, version: str=None, **options) -> Mapping:
         """
-        submit a specified DAP to this system for review.  The options supported depend on 
-        the implementation (and implementations should ignore any option parameters that 
-        it does not recognize; however, support for the following parameters are defined as 
-        follows:
+        submit a specified DAP to this system for review.  
+
+        The options supported depend on the implementation (and implementations should ignore 
+        any option parameters that it does not recognize); however, support for the following 
+        parameters are defined as follows:
         ``instructions``
              (*[str]*) a list of statements that should be passed as special instructions to 
              the reviewers.
@@ -56,15 +58,66 @@ class ExternalReviewClient(ABC):
              (*bool*) if True, this DAP includes content (e.g. software) that requires 
              review IT security review.  
 
-        :param str id:         the identifier for the DAP to submit to the review system
-        :param str submitter:  the identifier for the user submitting the DAP (this is 
-                               usually the owner of the record).
-        :param str version:    the version of the DAP being submitted.  This should be 
-                               provided when revising a previously published DAP; otherwise,
-                               the implementation may assume that the initial version is being 
-                               submitted.  
+        :param str          id:  the identifier for the DAP to submit to the review system
+        :param str   submitter:  the identifier for the user submitting the DAP (this is 
+                                 usually the owner of the record).
+        :param str     version:  the version of the DAP being submitted.  This should be 
+                                 provided when revising a previously published DAP; otherwise,
+                                 the implementation may assume that the initial version is being 
+                                 submitted.  
         :param Mapping options:  extra implementation-specific keyword parameters
+        :return:  a dictionary containing the data supported by :py:meth:`get_status`.
+                  :rtype: dict
         """
         raise NotImplemented()
 
+    @abstractmethod
+    def resubmit(self, id: str, revid: str, **options) -> Mapping:
+        """
+        resubmit an updated DAP (in response to reviewer feedback) to continue in previously 
+        started review process.
+
+        The options supported depend on the implementation (and implementations should ignore 
+        any option parameters that it does not recognize); however, support for the following 
+        parameters are defined as follows:
+        ``comments``
+             (*[str]*) a list of statements that should be passed as response to the reviewers'
+             feedback.  It can, for example, summarize the changes applied or how the changes 
+             addressed the feedback.  
+
+        :param str          id:  the identifier for the DAP to submit to the review system
+        :param str       revid:  an identifier for the open review process to resubmit to.  
+        :param Mapping options:  extra implementation-specific keyword parameters
+        :return:  a dictionary containing the data supported by :py:meth:`get_status`.
+                  :rtype: dict
+        """
+        raise NotImplemented()
+
+    @abstractmethod
+    def get_status(self, id: str, revid: str=None) -> Mapping:
+        """
+        request and return the status of the review for a given dataset as a dictionary.  
+
+        The exact contents for the returned dictionary is implementation-specific, but it should 
+        support the following properties:
+
+        ``id``
+            the MIDAS identifier for the record being reviewed
+        ``revid``
+            the identifier assigned by the review system for the current review being processed 
+            on the record.
+        ``phase``
+            an implementation-specific name for the phase that the review is currently in.
+        ``requestChanges``
+            True if the review is paused because changes were requested of the record's submitter
+        ``seeURL``
+            A URL that can be visited via a web browser to view the status of a review.
+        ``details``
+            a dictionary providing implementation-specific details about the review
+
+        :param str          id:  the identifier for the DAP to submit to the review system
+        :param str       revid:  an identifier for the open review process it is part of.  If not 
+                                 provided, an attempt to discover the process should be attempted.
+        """
+        raise NotImplemented()
 

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -22,13 +22,20 @@ class NPSExternalReviewClient(ExternalReviewClient):
     dictionary provided at construction time:
 
     ``draft_url_template``
-        (*str*) *required*. a string template for forming a URL where a reviewer can view the draft
+        _str_ (required). a string template for forming a URL where a reviewer can view the draft
         landing page for the DAP.  The template should include one "%s" insert point where the draft
         DAP ID can be inserted.
     ``published_url_template``
-        (*str*) *required*. a string template for forming a URL where the DAP will be viewable once
+        _str_ (required). a string template for forming a URL where the DAP will be viewable once
         it is published.  The template should include one "%s" insert point where the public
         DAP ID can be inserted.
+    ``nps_endpoint``
+        _str_ (required). the endpoint URL for the NPS service
+    ``tokenService``
+        _dict_ (required).  The configuration data that describes the service for retrieving an 
+        authentication token for use with the NPS service.  The sub-properties looked for in this 
+        dictionary the same as those documented for 
+        :py:func:`~nistoar.nsd.sync.syncer.get_nsd_auth_token`.  
     """
     system_name = "nps1"
 

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -221,8 +221,8 @@ class NPSExternalReviewClient(ExternalReviewClient):
         if instructions:
             payload["instructions"] = instructions
 
-        # NPS expects a POST to {nps_endpoint}/review/{record_id}
-        url = f"{self.nps_endpoint.rstrip('/')}/review/{id}"
+        # NPS expects a POST to {nps_endpoint}/DataSet/SubmitDataset/{record_id}
+        url = f"{self.nps_endpoint.rstrip('/')}/DataSet/SubmitDataset/{id}"
 
         # Send the request
         token = self._get_token()

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -266,7 +266,7 @@ class NPSExternalReviewClient(ExternalReviewClient):
         if resp.status_code == 200:
             try:
                 return resp.json()
-            except requests.exception.InvalidJSONError as ex:
+            except requests.exceptions.InvalidJSONError as ex:
                 log = logging.getLogger(self.log_name)
                 log.exception(ex)
                 log.warning("Unexpected error decoding JSON response:\n  %s", resp.text)

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -11,7 +11,7 @@ from nistoar.base.config import ConfigurationException
 from nistoar.nsd.service import PeopleService
 from nistoar.nsd.sync.syncer import get_nsd_auth_token
 from nistoar.midas.dap.extrev import ExternalReviewClient, ExternalReviewException
-from nistoar.nsd.service import PeopleService
+from nistoar.nsd.service import PeopleService, NSDException
 
 mdsid_re = re.compile(r'')
 
@@ -40,6 +40,7 @@ class NPSExternalReviewClient(ExternalReviewClient):
         :py:func:`~nistoar.nsd.sync.syncer.get_nsd_auth_token`.  
     """
     system_name = "nps1"
+    log_name = "ExternalReviewClient."+system_name
 
     _review_reasons = {
         "NEWREC":  "New Record",
@@ -132,11 +133,22 @@ class NPSExternalReviewClient(ExternalReviewClient):
         """
         reviewer = {
             "nistId": user["nistId"],
-            "firstName": user["firstName"],
-            "lastName": user["lastName"],
-            "eMail": user["eMail"],
+            "firstName": user.get("firstName", ""),
+            "lastName": user.get("lastName", ""),
+            "eMail": user.get("eMail", ""),
             "contactTypeId": 7 if is_owner else 21
         }
+        if self.ps:
+            # override with our own query to the people db
+            try:
+                person = self.ps.get_person_by_eid(reviewer['nistId'])
+                reviewer['firstName'] = person.get('firstName', reviewer['firstName'])
+                reviewer['lastName'] = person.get('lastName', reviewer['lastName'])
+                reviewer['eMail'] = person.get('emailAddress', reviewer['eMail'])
+            except NSDException as ex:
+                log = logging.getLogger(self.log_name)
+                log.error("Trouble accessing people service info for NPS: "+str(ex))
+            
         return reviewer
 
     def submit(self, id: str, submitter: str, version: str=None, **options):
@@ -185,23 +197,11 @@ class NPSExternalReviewClient(ExternalReviewClient):
         # Compose the reviewers list
         reviewers = []
         # First reviewer: record owner (submitter)
-        submitter_info = None
         if reviewers_opt:
             # If explicit reviewers are provided, first one is owner
-            submitter_info = reviewers_opt[0]
-        elif self.ps:
-            # Try to use PeopleService to resolve
-            submitter_info = self.ps.get_person(submitter)
+            reviewers.append(self._prepare_reviewer(reviewers_opt[0], is_owner=True))
         else:
-            # Fallback to submitter as is
-            submitter_info = {
-                "nistId": submitter,
-                "firstName": "",
-                "lastName": "",
-                "eMail": ""
-            }
-        reviewers.append(self._prepare_reviewer(submitter_info, is_owner=True))
-        # Add any other reviewers as tech reviewers (contactTypeId=21)
+            reviewers.append(self._prepare_reviewer({"nistId": submitter}, is_owner=True))
         for user in reviewers_opt[1:]:
             reviewers.append(self._prepare_reviewer(user, is_owner=False))
 
@@ -222,7 +222,7 @@ class NPSExternalReviewClient(ExternalReviewClient):
         payload = {
             "dataSetID": id,
             "itSecurityReview": bool(security_review),
-            "submitterID": submitter_info["nistId"],
+            "submitterID": reviewers[0]['nistId'],
             "pdR_URL": pub_url,
             "dataPub_URL": draft_url,
             "title": title,
@@ -260,7 +260,7 @@ class NPSExternalReviewClient(ExternalReviewClient):
                                           self.system_name, resp.status_code)
         else:
             if resp.status_code == 400:
-                log = logging.getLogger("ExternalReviewClient."+self.system_name)
+                log = logging.getLogger(self.log_name)
                 log.info("POSTed input: \n%s", json.dumps(payload))
             raise ExternalReviewException(
                 f"NPS API error: {resp.status_code} {resp.reason}\n  {url}",

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -1,7 +1,7 @@
 """
 An implementation of the ExternalReviewClient that talks to the NPS (version 1)
 """
-import json, re
+import json, re, logging
 from typing import List, Dict, Any
 from collections import OrderedDict
 
@@ -235,15 +235,21 @@ class NPSExternalReviewClient(ExternalReviewClient):
         try:
             resp = requests.post(url, headers=headers, data=json.dumps(payload), timeout=30)
         except Exception as ex:
-            raise ExternalReviewException(f"Failed to POST to NPS: {ex}")
+            raise ExternalReviewException(f"Failed to POST to NPS: {ex}", self.system_name)
 
         if resp.status_code == 200:
             return resp.json()
         elif resp.status_code == 401:
-            raise ExternalReviewException("Unauthorized: Check the NPS API token and permissions.")
+            raise ExternalReviewException("Unauthorized: Check the NPS API token and permissions.",
+                                          self.system_name, resp.status_code)
         elif resp.status_code == 403:
-            raise ExternalReviewException("Forbidden: Record is not currently in review.")
+            raise ExternalReviewException("Forbidden: Record is not currently in review.",
+                                          self.system_name, resp.status_code)
         else:
+            if resp.status_code == 400:
+                log = logging.getLogger("ExternalReviewClient."+self.system_name)
+                log.info("POSTed input: \n%s", json.dumps(payload))
             raise ExternalReviewException(
-                f"NPS API error: {resp.status_code} {resp.reason}\n  {url}"
+                f"NPS API error: {resp.status_code} {resp.reason}\n  {url}",
+                self.system_name, resp.status_code
             )

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -11,6 +11,7 @@ from nistoar.base.config import ConfigurationException
 from nistoar.nsd.service import PeopleService
 from nistoar.nsd.sync.syncer import get_nsd_auth_token
 from nistoar.midas.dap.extrev import ExternalReviewClient, ExternalReviewException
+from nistoar.nsd.service import PeopleService
 
 mdsid_re = re.compile(r'')
 
@@ -94,6 +95,18 @@ class NPSExternalReviewClient(ExternalReviewClient):
         draft_url = self._drafturl_tmpl % record_id
         pub_url = self._puburl_tmpl % (pubid if pubid else record_id)
         return draft_url, pub_url
+
+    @property
+    def people_service(self):
+        """
+        the instance of a PeopleService that will be used for resolving user IDs, or None if not 
+        available.
+        """
+        return self.ps
+
+    @people_service.setter
+    def people_service(self, svc: PeopleService):
+        self.ps = svc
 
     def select_review_reason(self, changes: List[str] = None, version: str = None) -> str:
         """

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -261,10 +261,17 @@ class NPSExternalReviewClient(ExternalReviewClient):
         try:
             resp = requests.post(url, headers=headers, data=json.dumps(payload), timeout=30)
         except Exception as ex:
-            raise ExternalReviewException(f"Failed to POST to NPS: {ex}", self.system_name)
+            raise ExternalReviewException(f"Failed to POST to NPS: {ex}", self.system_name) from ex
 
         if resp.status_code == 200:
-            return resp.json()
+            try:
+                return resp.json()
+            except requests.exception.InvalidJSONError as ex:
+                log = logging.getLogger(self.log_name)
+                log.exception(ex)
+                log.warning("Unexpected error decoding JSON response:\n  %s", resp.text)
+                raise ExternalReviewException("Unexpected JSON-decoding error in response to successful "+
+                                              "submission: "+str(ex)) from ex
         elif resp.status_code == 401:
             raise ExternalReviewException("Unauthorized: Check the NPS API token and permissions.",
                                           self.system_name, resp.status_code)

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -1,7 +1,7 @@
 """
 An implementation of the ExternalReviewClient that talks to the NPS (version 1)
 """
-import json
+import json, re
 from typing import List, Dict, Any
 from collections import OrderedDict
 
@@ -12,6 +12,7 @@ from nistoar.nsd.service import PeopleService
 from nistoar.nsd.sync.syncer import get_nsd_auth_token
 from nistoar.midas.dap.extrev import ExternalReviewClient, ExternalReviewException
 
+mdsid_re = re.compile(r'')
 
 class NPSExternalReviewClient(ExternalReviewClient):
     """
@@ -194,6 +195,15 @@ class NPSExternalReviewClient(ExternalReviewClient):
         # Set the review reason if not given
         if not review_reason:
             review_reason = self.select_review_reason(changes, version)
+
+        m = re.search(r':\d+$', id)
+        if m:
+            # NPS1: use only record number portion of ID
+            try:
+                id = int(id.rsplit(':', 1)[-1])
+            except ValueError as ex:
+                # should not happen
+                pass
 
         # Build the request payload
         payload = {

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -141,14 +141,27 @@ class NPSExternalReviewClient(ExternalReviewClient):
         if self.ps:
             # override with our own query to the people db
             try:
-                person = self.ps.get_person_by_eid(reviewer['nistId'])
+                if isinstance(reviewer['nistId'], int):
+                    # id is the integer person record ID
+                    person = self.get_person(reviewer['nistId'])
+                elif isinstance(reviewer['nistId'], str):
+                    # id is the enterprise ID
+                    person = self.ps.get_person_by_eid(reviewer['nistId'])
+                    reviewer['nistId'] = person['peopleID']
+                else:
+                    raise ValueError("user['nistId']: unsupported type: "+type(user['nistId']))
+
                 reviewer['firstName'] = person.get('firstName', reviewer['firstName'])
                 reviewer['lastName'] = person.get('lastName', reviewer['lastName'])
                 reviewer['eMail'] = person.get('emailAddress', reviewer['eMail'])
+
             except NSDException as ex:
                 log = logging.getLogger(self.log_name)
                 log.error("Trouble accessing people service info for NPS: "+str(ex))
-            
+
+        elif isinstance(reviewer['nistId'], str):
+            raise NSDException("No people service configured available to lookup int people ID")
+
         return reviewer
 
     def submit(self, id: str, submitter: str, version: str=None, **options):

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -221,8 +221,8 @@ class NPSExternalReviewClient(ExternalReviewClient):
         if instructions:
             payload["instructions"] = instructions
 
-        # NPS expects a POST to {nps_endpoint}/DataSet/SubmitDataset/{record_id}
-        url = f"{self.nps_endpoint.rstrip('/')}/DataSet/SubmitDataset/{id}"
+        # NPS expects a POST to {nps_endpoint}/DataSet/SubmitDataset
+        url = f"{self.nps_endpoint.rstrip('/')}/DataSet/SubmitDataset"
 
         # Send the request
         token = self._get_token()
@@ -245,5 +245,5 @@ class NPSExternalReviewClient(ExternalReviewClient):
             raise ExternalReviewException("Forbidden: Record is not currently in review.")
         else:
             raise ExternalReviewException(
-                f"NPS API error: {resp.status_code} {resp.reason}\n{resp.text}"
+                f"NPS API error: {resp.status_code} {resp.reason}\n  {url}"
             )

--- a/python/nistoar/midas/dap/extrev/nps1.py
+++ b/python/nistoar/midas/dap/extrev/nps1.py
@@ -2,8 +2,9 @@
 An implementation of the ExternalReviewClient that talks to the NPS (version 1)
 """
 import json, re, logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union, Mapping
 from collections import OrderedDict
+from urllib.parse import urlparse
 
 import requests
 
@@ -72,6 +73,7 @@ class NPSExternalReviewClient(ExternalReviewClient):
         """
         super(NPSExternalReviewClient, self).__init__(config)
         self.ps = peopsvc  # may be None
+        self._token = None
 
         # get templates for the home page URL from config
         self._drafturl_tmpl = self.cfg.get("draft_url_template")
@@ -85,6 +87,11 @@ class NPSExternalReviewClient(ExternalReviewClient):
         self.nps_endpoint = self.cfg.get("nps_endpoint")
         if not self.nps_endpoint:
             raise ConfigurationException("Missing required config param: nps_endpoint")
+
+        self.fbcli = None
+        fbcfg = self.cfg.get("nps_feedback")
+        if fbcfg:
+            self.fbcli = ExternalReviewFeedbackClient(fbcfg)
 
     def _get_token(self):
         service_config = self.cfg.get("tokenService")
@@ -164,7 +171,7 @@ class NPSExternalReviewClient(ExternalReviewClient):
 
         return reviewer
 
-    def submit(self, id: str, submitter: str, version: str=None, **options):
+    def submit(self, id: str, submitter: str, version: str=None, **options) -> Mapping:
         """
         submit a specified DAP to this system for review.  This implementation supports the
         following extra options:
@@ -251,15 +258,97 @@ class NPSExternalReviewClient(ExternalReviewClient):
         url = f"{self.nps_endpoint.rstrip('/')}/DataSet/SubmitDataset"
 
         # Send the request
-        token = self._get_token()
+        if not self._token:
+            self._token = self._get_token()
         headers = {
-            "Authorization": f"Bearer {token}",
+            "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
             "Accept": "application/json"
         }
 
         try:
             resp = requests.post(url, headers=headers, data=json.dumps(payload), timeout=30)
+        except Exception as ex:
+            raise ExternalReviewException(f"Failed to POST to NPS: {ex}", self.system_name) from ex
+
+        if resp.status_code == 401:
+            raise ExternalReviewException("Unauthorized: Check the NPS API token and permissions.",
+                                          self.system_name, resp.status_code)
+        elif resp.status_code == 403:
+            raise ExternalReviewException("Forbidden: Record is not currently in review.",
+                                          self.system_name, resp.status_code)
+        elif resp.status_code >= 300 or resp.status_code < 200:
+            if resp.status_code == 400:
+                log = logging.getLogger(self.log_name)
+                log.info("POSTed input: \n%s", json.dumps(payload))
+            raise ExternalReviewException(
+                f"Unexpected NPS API error: {resp.status_code} {resp.reason}\n  {url}",
+                self.system_name, resp.status_code
+            )
+
+        # Looks successful; now get the updated status
+        return self._refresh_status(id)
+
+    def get_status(self, id: Union[str, int], revid: str=None) -> Mapping:
+        """
+        request and return the status of the review for a given dataset
+
+        :param str          id:  the identifier for the DAP to submit to the review system
+        :param str       revid:  an identifier for the open review process to resubmit to
+        """
+        if isinstance(id, str):
+            m = re.search(r':\d+$', id)
+            if m:
+                # NPS1: use only record number portion of ID
+                try:
+                    id = int(id.rsplit(':', 1)[-1])
+                except ValueError as ex:
+                    # should not happen
+                    pass
+
+        if not revid and revid != 0:
+            npsstat = self._discover_status(id)
+            revid = npsstat.get('taskID')
+        else:
+            npsstat = self._get_status("/DataSet/GetByID", id, revid)
+        
+        out = {
+            "id": id,
+            "systemID": revid,
+            "phase": npsstat.get('taskDescription', 'in progress'),
+            "requestChanges": False
+        }
+        if self.cfg.get('review_url_template'):
+            out['seeURL'] = self.cfg['review_url_template'] % {'dataSetID': id, 'taskID': revid}
+            
+        if npsstat.get('submitterID') == npsstat.get('assigneeNistId'):
+            out['phase'] = "changes requested"
+            out["requestChanges"] = True
+
+        out['details'] = npsstat
+        return out
+
+    def _discover_status(self, id: int):
+        tasks = self._get_status("/DataSet/GetActiveTasks", id)
+        if len(tasks) == 0:
+            raise ExternalReviewException("Not Found: Record does not currently have a review task",
+                                          self.system_name, resp.status_code)
+        return tasks[-1]
+
+    def _get_status(self, relurl: str, id: int, revid: str=None):
+        if not self._token:
+            self._token = self._get_token()
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json"
+        }
+        
+        url = f"{self.nps_endpoint.rstrip('/')}{relurl}?dataSetID={id}"
+        if revid:
+            url += f"&taskID={revid}"
+
+        try:
+            resp = requests.get(url, headers=headers)
         except Exception as ex:
             raise ExternalReviewException(f"Failed to POST to NPS: {ex}", self.system_name) from ex
 
@@ -271,18 +360,325 @@ class NPSExternalReviewClient(ExternalReviewClient):
                 log.exception(ex)
                 log.warning("Unexpected error decoding JSON response:\n  %s", resp.text)
                 raise ExternalReviewException("Unexpected JSON-decoding error in response to successful "+
-                                              "submission: "+str(ex)) from ex
+                                              "request: "+str(ex)) from ex
+                    
         elif resp.status_code == 401:
             raise ExternalReviewException("Unauthorized: Check the NPS API token and permissions.",
                                           self.system_name, resp.status_code)
         elif resp.status_code == 403:
             raise ExternalReviewException("Forbidden: Record is not currently in review.",
                                           self.system_name, resp.status_code)
+        elif resp.status_code == 404:
+            raise ExternalReviewException("Not Found: Record is not currently in review",
+                                          self.system_name, resp.status_code)
         else:
-            if resp.status_code == 400:
-                log = logging.getLogger(self.log_name)
-                log.info("POSTed input: \n%s", json.dumps(payload))
             raise ExternalReviewException(
                 f"NPS API error: {resp.status_code} {resp.reason}\n  {url}",
                 self.system_name, resp.status_code
             )
+
+    def resubmit(self, id: Union[str,int], revid: Union[str,int]=None, **options) -> Mapping:
+
+        if isinstance(id, str):
+            m = re.search(r':\d+$', id)
+            if m:
+                # NPS1: use only record number portion of ID
+                try:
+                    id = int(id.rsplit(':', 1)[-1])
+                except ValueError as ex:
+                    # should not happen
+                    pass
+
+        if not revid:
+            status = self.get_status(id)
+            revid = status.get('taskId')
+
+        comments = options.get('comments', ["Resubmitting for further review"])
+        if isinstance(comments, list):
+            comments = "\n\n".join(comments)
+
+        data = {
+            "taskID": revid,
+            "comments": comments
+        }
+        
+        if not self._token:
+            self._token = self._get_token()
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        }
+        
+        url = self.nps_endpoint.rstrip('/') + "/DataSet/RevisionCompleted"
+        try:
+            resp = requests.post(url, headers=headers, json=data)
+        except Exception as ex:
+            raise ExternalReviewException(f"Failed to POST to NPS: {ex}", self.system_name) from ex
+
+        if resp.status_code == 401:
+            raise ExternalReviewException("Unauthorized: Check the NPS API token and permissions.",
+                                          self.system_name, resp.status_code)
+        elif resp.status_code == 403:
+            raise ExternalReviewException("Forbidden: Record is not currently in review.",
+                                          self.system_name, resp.status_code)
+        elif resp.status_code >= 300 or resp.status_code < 200:
+            if resp.status_code == 400:
+                log = logging.getLogger(self.log_name)
+                log.info("POSTed input: \n%s", json.dumps(payload))
+            raise ExternalReviewException(
+                f"Unexpected NPS API error: {resp.status_code} {resp.reason}\n  {url}",
+                self.system_name, resp.status_code
+            )
+
+        # Looks successful; now get the updated status
+        return self._refresh_status(id, revid)
+
+    def _refresh_status(self, id: str, revid: str=None) -> Mapping:
+        out = self.get_status(id, revid)
+
+        feedback = None
+        if out['requestChanges']:
+            feedback = { 'description': "Changes requested; visit NPS site for details" }
+
+        if self.fbcli:
+            try:
+                self.fbcli.send_feedback(out['id'], out['phase'], revid, feedback, out['requestChanges'])
+            except Exception as ex:
+                logging.getLogger(self.log_name).exception(ex)
+
+        return out
+
+    def refresh_status(self, id: str, revid: str=None) -> bool:
+        """
+        pull the latest status from NPS and push it into the DAP record via the feedback service.
+        
+        This method essentially calls the feedback service on behalf of the legacy NPS service, 
+        which cannot do this on its own.  For this to work, this client must have been configured 
+        with details on the feedback service via the ``nps_feedback`` configuration parameter.  
+
+        :param str          id:  the identifier for the DAP to submit to the review system
+        :param str       revid:  an identifier for the open review process it is part of.  If not 
+                                 provided, an attempt to discover the process should be attempted.
+        :return:  True if the status was successfully updated.
+        """
+        if not self._fbcli:
+            return False
+
+        try:
+            status = self._refresh_status(id, revid)
+            return True
+        except ExternalReviewException as ex:
+            # log issue
+            log = logging.getLogger(self.log_name)
+            log.error("Failed to push latest review status as requested: "+str(ex))
+            return False
+        except Exception as ex:
+            # log issue
+            log = logging.getLogger(self.log_name)
+            log.error("Unexpected error while pushing latest review status: "+str(ex))
+            return False
+
+class ExternalReviewFeedbackClient:
+    """
+    A client to the :py:mod:`external review feedback service<nistoar.midas.dap.extrev.wsgi>` provided
+    specifically for the legacy NPS service.  
+
+    The legacy NPS service does not have the ability to respond back to MIDAS about review status updates 
+    except when review is successfully completed.  This client is used by the 
+    :py:class:`NPSExternalReviewClient` to instead pull back the status to MIDAS on NPS's behalf.  
+    """
+
+    def __init__(self, config):
+        self.ep = config.get('service_endpoint')
+        if not self.ep:
+            raise ConfigurationException("ExternalReviewFeedbackClient: Missing required param: "+
+                                         "service_endpoint")
+        if not self.ep.endswith('/'):
+            self.ep += '/'
+
+        self.sysname = "nps1"
+        try:
+            urlp = urlparse(self.ep)
+            path = urlp.path.strip('/').split('/')
+            if len(path) > 1:
+                self.sysname = '/'.join(path[-2:])
+            elif len(path) > 0:
+                self.sysname = path[-1]
+        except ValueError as ex:
+            raise ConfigurationException("ExternalReviewFeedbackClient: service_endpoint: not a legal URL: "+
+                                         str(self.ep))
+
+        self.hdrs = {}
+        if config.get('auth_key'):
+            self.hdrs['Authorization'] = f"Bearer {config.get('auth_key')}"
+
+    def send_feedback(self, id: str, phase: str, feedback: Union[Mapping, List]=None,
+                      request_changes: bool=False, info_url: str=None, revid: int=None):
+        """
+        update the status of a review.
+
+        The main purpose of this function is to allow for updating the label indicating the phase 
+        of that the review is currently in: the review system would send such a message each time 
+        the review enters a new phase or step.  The update can also optionally provide specific 
+        instructions for requested changes, provided as a list of dictionaries where each dictionary 
+        can have the following properties (corresponding to those supported by 
+        :py:meth:`Status.pubreview() <nistoar.midas.dbio.status.pubreview>`):
+
+        ``description``
+            (str) _required_.  text describing the request or comment
+        ``reviewer``
+            (str) _recommended_.  a user identifier or full name of the reviewer or other origin of 
+            this instruction
+        ``type``
+            (str) _optional_.  a label indicating the type of feedback.  Special values include, 
+            ``req`` (required to be addressed for approval), ``warn`` (not required but of potentially
+            serious concern or otherwise strongly recommended), ``rec`` (recommended to be addressed),
+            and ``comment`` (just a comment with no explicit recommendation being made).  Other values
+            are allowed (as defined by the external system) but will be interpreted by default as 
+            comments.
+
+        :param str        id:  the identifier for the records being reviewed
+        :param str     phase:  the current phase or step that the review is currently in
+        :param dict|list feedback:  instructions or comments to be provided back to the record's authors.
+                               A single piece of feedback can be provided in dictionary form (see above); 
+                               Multiple feedback instructions are given as an list of such dictionaries.
+        :param bool request_changes:  an indicator as to whether the reviewer(s) require that changes
+                               be made according to the information in the ``feedback`` parameter.  
+                               If True, the record permissions will be reset to allow authors to 
+                               make corrections; when False (or not provided), the information provided
+                               in ``feedback`` can be considered optional or commentary.  
+        :param str  info_url:  a URL that authors can access to see the state of the review of the 
+                               record within the NPS system.
+        :param int     revid:  the identifier that NPS uses to track this review.  It is expected that 
+                               this is the ID that the NPS API requires for interacting with the review 
+                               state. 
+        """
+        if not revid:
+            revid = self._surmise_revid(id)
+
+        msg = {
+            "systemID": revid,
+            "phase": phase
+        }
+        if info_url is not None:
+            msg['info_at'] = info_url
+        if feedback:
+            if not isinstance(feedback, (Mapping, List)):
+                raise TypeError(f"send_feedback: bad type for feedback ({type(feedback)}): not list or dict")
+            if not isinstance(feedback, List):
+                feedback = [ feedback ]
+            msg['feedback'] = feedback
+        if request_changes is True:
+            msg['changesRequested'] = True
+
+        return self._send(id, msg, 'PUT')
+
+    def _surmise_revid(self, id: str):
+        revid = -1
+        
+        m = re.match("^mds\d+:0*(\d+)$", id)
+        if m:
+            try:
+                revid = int(m.group(1))
+            except ValueError as ex:
+                # should not happen
+                pass
+
+        return revid
+
+    def legacy_approve(self, id: str):
+        """
+        send an approval message using the legacy MIDAS-NPS API interface
+        """
+        return self._send(id, { "reviewResponse": True }, 'POST')
+
+    def approve(self, id: str, info_url: str=None, revid: int=None):
+        """
+        send an approval message using the new standard feedback API
+        """
+        if not revid:
+            revid = self._surmise_revid(id)
+
+        msg = {
+            "systemID": revid,
+            "phase": "approved"
+        }
+        if infor_url:
+            msg['info_at'] = info_url
+        return self._send(id, msg, 'PUT')
+
+    def cancel(self, id: str, info_url: str=None, revid: int=None):
+        """
+        request that the review process be canceled 
+        """
+        if not revid:
+            revid = self._surmise_revid(id)
+
+        msg = {
+            "systemID": revid,
+            "phase": "canceled"
+        }
+        if info_url:
+            msg['info_at'] = info_url
+        return self._send(id, msg, 'PUT')
+
+    def _send(self, id: str, message: Mapping, method='PUT'):
+        url = self.ep + id
+        emsg = "Failed to send review feedback: "
+
+        try:
+            resp = requests.request(method, url, json=message, headers=self.hdrs)
+        except Exception as ex:
+            raise ExternalReviewException(emsg + "comm failure: " + str(ex))
+
+        return self._extract_reply_data(resp)
+
+    def _extract_reply_data(self, resp):
+        emsg = "Failed to send review feedback: "
+
+        reply = { "oar:message": resp.reason }
+        try:
+            reply = resp.json()
+        except Exception as ex:
+            if resp.status_code >= 200 and resp.status_code < 300:
+                reply = { "oar:message": "Corrupted response message" }
+
+        if resp.status_code == 401:
+            raise ExternalReviewException(emsg + f"authentication failure ({reply['oar:message']})",
+                                          self.sysname, resp.status_code)
+        elif resp.status_code == 404:
+            raise ExternalReviewException(emsg +f"record not found ({reply['oar:message']})",
+                                          self.sysname, resp.status_code)
+        elif resp.status_code >= 500:
+            raise ExternalReviewException(emsg +f"Unexpected server failure: ({str(resp.status_code)}) " +
+                                          reply['oar:message'], self.sysname, resp.status_code)
+        elif resp.status_code >= 300 or resp.status_code < 200:
+            raise ExternalReviewException(emsg + f"Unexpected {str(resp.status_code)} response: " +
+                                          reply['oar:message'], self.sysname, resp.status_code)
+
+        resp.close()
+        return reply
+
+    def get_review(self, id: str):
+        """
+        return the summary of the review of the DAP with the given identifier
+        """
+        url = self.ep + id
+        
+        try:
+            resp = requests.get(url, headers=self.hdrs)
+        except Exception as ex:
+            raise ExternalReviewException("Unable to retrieve review summary due to comm failure: " +
+                                          str(ex))
+
+        try:
+            return self._extract_reply_data(resp)
+        finally:
+            resp.close()
+
+            
+    
+        
+
+            

--- a/python/nistoar/midas/dap/extrev/sim.py
+++ b/python/nistoar/midas/dap/extrev/sim.py
@@ -16,7 +16,7 @@ class SimulatedExternalReviewClient(ExternalReviewClient):
     """
     system_name = "simulated"
 
-    def __init__(self, config, autoapprove: bool=True, projsvc: ProjectService = None):
+    def __init__(self, config, autoapprove: bool=False, projsvc: ProjectService = None):
         """
         initialize the client
         :param dict config:  the configuration operating this external review client
@@ -25,6 +25,8 @@ class SimulatedExternalReviewClient(ExternalReviewClient):
         super(SimulatedExternalReviewClient, self).__init__(config)
         self.projsvc = projsvc
         self.autoapp = autoapprove
+        if config.get('as_system'):
+            self.system_name = config['as_system']
 
         self.cbsvc = None
         cbcfg = self.cfg.get("call_back")

--- a/python/nistoar/midas/dap/extrev/sim.py
+++ b/python/nistoar/midas/dap/extrev/sim.py
@@ -36,7 +36,7 @@ class SimulatedExternalReviewClient(ExternalReviewClient):
 
         self.projs = {}
 
-    def submit(self, id: str, submitter: str, version: str=None, **options):
+    def submit(self, id: str, submitter: str, version: str=None, **options) -> Mapping:
         if id in self.projs and self.projs[id].get('phase','approved') != 'approved':
             raise ExternalReviewException(f"Already under review with the {self.system_name} review system")
 
@@ -50,7 +50,25 @@ class SimulatedExternalReviewClient(ExternalReviewClient):
             extra = {}
             if options.get('can_publish'):
                 extra['publish'] = True
+            self.projs[id]['phase'] = 'approved'
             self.approve(id, **extra)
+
+        else:
+            self.update(id, self.projs[id]['phase'])
+
+        return self.projs[id]
+
+    def get_status(self, id: str, revid: str=None) -> Mapping:
+        return self.projs.get(id)
+
+    def resubmit(self, id: str, revid: str, **options) -> Mapping:
+        if not self.projs.get(id):
+            self.projs[id] = { "submitter": "nobody" }
+                
+        self.projs[id]['phase'] = "restarted"
+        self.projs[id]['options'] = options
+
+        return self.projs[id]
 
     def approve(self, id, publish: bool=False):
         if id not in self.projs:

--- a/python/nistoar/midas/dap/extrev/wsgi.py
+++ b/python/nistoar/midas/dap/extrev/wsgi.py
@@ -1,0 +1,195 @@
+"""
+Web service interface used by the legacy NPS review system to deliver review status updates on DAP 
+records.
+
+This interface provides a REST interface that is compatible with the legacy communication protocol
+between MIDAS and NPS; in addition, it provides a fuller interface for a next generation protocol.  In 
+the legacy protocol, NPS will only respond when a reviewer requests chagnes or the review completes 
+to full approval.
+"""
+
+import logging, re, json
+from logging import Logger
+from collections import OrderedDict
+from typing import List, Mapping, Callable
+
+from nistoar.midas import dbio
+from nistoar.midas.dbio.project import ProjectService, ProjectServiceFactory
+from nistoar.midas.dap.service import mds3
+from nistoar.pdr.utils.prov import Agent
+from nistoar.web.rest import (ServiceApp, Handler, HandlerWithJSON, AuthenticatedWSGIApp,
+                              authenticate_via_authkey, FatalError)
+from ... import system
+
+deflog = logging.getLogger(system.system_abbrev)   \
+                .getChild('extrev').getChild('nps')
+
+DEF_BASE_PATH = '/extrev/nps/leg/'
+DEF_DBIO_CLIENT_FACTORY_CLASS = dbio.InMemoryDBClientFactory
+DEF_DBIO_CLIENT_FACTORY_NAME  = "inmem"
+
+class LegacyNPSFeedbackHandler(HandlerWithJSON):
+    """
+    the main handler receiving external review feedback
+    """
+    def __init__(self, project_service: ProjectService, path: str, wsgienv: dict, start_resp: Callable,
+                 who=None, log: Logger=None, config: Mapping={}, app=None):
+        super(LegacyNPSFeedbackHandler, self).__init__(path, wsgienv, start_resp, who, config, log, app)
+        self._svc = project_service
+
+    def get_json_body(self):
+        try:
+            bodyin = self._env.get('wsgi.input')
+            if bodyin is None:
+                raise FatalError(400, "Missing input", "Missing expected input JSON data")
+            
+            return json.load(bodyin, object_pairs_hook=OrderedDict)
+
+        except (ValueError, TypeError) as ex:
+            if self.log.isEnabledFor(logging.DEBUG):
+                self.log.error("Failed to parse input: %s", str(ex))
+                self.log.debug("\n%s", body)
+            raise FatalError(400, "Input not parseable as JSON",
+                             "Input document is not parse-able as JSON: "+str(ex))
+
+    def do_POST(self, path):
+        """
+        receive feedback: either approval or rejection
+        """
+        if not path:
+            return self.send_error_obj(404, "POST not allowed",
+                                       "Cannot POST to this resource without an ID")
+        id = path
+
+        try:
+            input = self.get_json_body()
+        except FatalError as ex:
+            return self.send_fatal_error(ex)
+
+        try:
+            if input.get('reviewResponse') is None:
+                # interpret a missing response as indicating that the review has started
+                self._svc.apply_external_review(id, "nps", "in progress", id)
+
+            elif input.get('reviewResponse'):
+                # review is approved
+                self._svc.approve(id, "nps", id)
+
+            else:
+                # reviewer wants changes
+                fb = [{ "type": "req", "description": "Visit NPS for reviewer comments" }]
+                self._svc.apply_external_review(id, "nps", "paused", id, feedback=fb, request_changes=True)
+
+            status = self._get_review_status_for(id)
+        
+        except dbio.NotAuthorized as ex:
+            return self.send_error_obj(409, "Not Reviewable",
+                                       "Record has not been submitted for review, yet", {"id": id})
+        except dbio.ObjectNotFound as ex:
+            return self.send_error_obj(404, "ID not found",
+                                       "Record with requested identifier not found", {"id": id})
+
+        return self.send_json(status)
+
+
+    def do_GET(self, path, ashead=False):
+
+        if path:
+            try:
+                return self.send_json(self._get_review_status_for(path))
+            except dbio.NotAuthorized as ex:
+                return self.send_unauthorized()
+            except dbio.ObjectNotFound as ex:
+                return self.send_error_obj(404, "ID not found",
+                                           "Record with requested identifier not found", id)
+
+        try:
+            return self._select_open_reviews()
+        except dbio.NotAuthorized as ex:
+            return self.send_unauthorized()
+
+    def _get_review_status_for(self, id):
+        prec = self._svc.dbcli.get_record_for(id, dbio.ACLs.PUBLISH)  # may raise exc
+        rev = prec.status.get_review_from("nps")
+        if not rev:
+            rev = {}
+        return rev
+
+    def _select_open_reviews(self):
+        recs = self._svc.dbcli.select_records(dbio.ACLs.PUBLISH)
+
+        out = []
+        for prec in recs:
+            rev = prec.status.get_review_from("nps")
+            if rev and rev.get('phase') != "approved":
+                out.append(rev)
+
+        return self.send_json(out)
+
+class LegacyNPSServiceApp(ServiceApp):
+    """
+    the web service to receive feedback from the legacy version of NPS
+    """
+
+    def __init__(self, service_factory: ProjectServiceFactory, log: Logger, config: Mapping={}):
+        super(LegacyNPSServiceApp, self).__init__("legacyNPS", log, config)
+        self.svcfact = service_factory
+
+    def create_handler(self, env: dict, start_resp: Callable, path: str, who: Agent) -> Handler:
+        """
+        return a handler instance to handle a particular request to a path
+        :param Mapping env:  the WSGI environment containing the request
+        :param Callable start_resp:  the start_resp function to use initiate the response
+        :param str    path:  the path to the resource being requested.  This is usually 
+                             relative to a parent path that this ServiceApp is configured to 
+                             handle.  
+        :param Agent   who:  the authenticated user agent making the request
+        """
+
+        # create a service on attached to the user
+        service = self.svcfact.create_service_for(who)
+
+        return LegacyNPSFeedbackHandler(service, path, env, start_resp, who, self.log, self.cfg, self)
+
+class ExternalReviewApp(AuthenticatedWSGIApp):
+
+    DB_FACTORY_CLASSES = {
+        "inmem":    dbio.InMemoryDBClientFactory,
+        "fsbased":  dbio.FSBasedDBClientFactory,
+        "mongo":    dbio.MongoDBClientFactory
+    }
+
+    def __init__(self, config: Mapping, dbio_client_factory: dbio.DBClientFactory=None, base_ep: str=None):
+        log = deflog
+        if config.get('base_log_name'):
+            log = logging.getLogger(config['base_log_name'])
+        baseep = base_ep or DEF_BASE_PATH
+        if config.get('base_ep_path'):
+            baseep = config['base_ep_path']
+        
+        super(ExternalReviewApp, self).__init__(config, log, baseep, "nps")
+
+        if not dbio_client_factory:
+            dbclsnm = self.cfg.get('dbio', {}).get('factory')
+            if not dbclsnm:
+                dbclsnm = DEF_DBIO_CLIENT_FACTORY_NAME
+            dbcls = self.DB_FACTORY_CLASSES.get(dbclsnm)
+            if dbcls:
+                dbcls = DEF_DBIO_CLIENT_FACTORY_CLASS
+            dbio_client_factory = dbcls(self.cfg.get('dbio', {}))
+
+        self.svcfact = mds3.DAPServiceFactory(dbio_client_factory, self.cfg.get('dap_service', {}), log)
+
+    def authenticate_user(self, env: Mapping, agents: List[str]=None, client_id: str=None) -> Agent:
+        """
+        determine the authenticated user
+        """
+        authcfg = self.cfg.get('authentication')
+        if authcfg:
+            return authenticate_via_authkey("midas", env, authcfg, self.log, agents, client_id)
+        return None
+
+    def handle_path_request(self, path: str, env: Mapping, start_resp: Callable, who = None):
+        svcapp = LegacyNPSServiceApp(self.svcfact, self.log, self.cfg.get('dap', {}))
+        return svcapp.create_handler(env, start_resp, path, who).handle()
+

--- a/python/nistoar/midas/dap/extrev/wsgi.py
+++ b/python/nistoar/midas/dap/extrev/wsgi.py
@@ -109,6 +109,15 @@ class LegacyNPSFeedbackHandler(HandlerWithJSON):
             return self.send_unauthorized()
 
     def _get_review_status_for(self, id):
+        # nps1 review ID is an integer
+        try:
+            recn = int(id)
+            while recn < 1000:
+                id = "0"+id
+                recn *= 10
+        except ValueError:
+            pass
+            
         prec = self._svc.dbcli.get_record_for(id, dbio.ACLs.PUBLISH)  # may raise exc
         rev = prec.status.get_review_from("nps1")
         if not rev:

--- a/python/nistoar/midas/dap/extrev/wsgi.py
+++ b/python/nistoar/midas/dap/extrev/wsgi.py
@@ -32,6 +32,8 @@ class LegacyNPSFeedbackHandler(HandlerWithJSON):
     """
     the main handler receiving external review feedback
     """
+    system_name = "nps1"
+    
     def __init__(self, project_service: ProjectService, path: str, wsgienv: dict, start_resp: Callable,
                  who=None, log: Logger=None, config: Mapping={}, app=None):
         super(LegacyNPSFeedbackHandler, self).__init__(path, wsgienv, start_resp, who, config, log, app)
@@ -54,10 +56,12 @@ class LegacyNPSFeedbackHandler(HandlerWithJSON):
 
     def do_POST(self, path):
         """
-        receive feedback: either approval or rejection
+        receive feedback: either approval or rejection.  
+
+        This replicates the legacy interface that NPS calls back to MIDAS with.
         """
         if not path:
-            return self.send_error_obj(404, "POST not allowed",
+            return self.send_error_obj(405, "POST not allowed",
                                        "Cannot POST to this resource without an ID")
         id = path
 
@@ -69,16 +73,16 @@ class LegacyNPSFeedbackHandler(HandlerWithJSON):
         try:
             if input.get('reviewResponse') is None:
                 # interpret a missing response as indicating that the review has started
-                self._svc.apply_external_review(id, "nps1", "in progress", id)
+                self._svc.apply_external_review(id, self.system_name, "in progress", id)
 
             elif input.get('reviewResponse'):
                 # review is approved
-                self._svc.approve(id, "nps1", id)
+                self._svc.approve(id, self.system_name, id)
 
             else:
                 # reviewer wants changes
                 fb = [{ "type": "req", "description": "Visit NPS for reviewer comments" }]
-                self._svc.apply_external_review(id, "nps1", "paused", id, feedback=fb, request_changes=True)
+                self._svc.apply_external_review(id, self.system_name, "paused", id, feedback=fb, request_changes=True)
 
             status = self._get_review_status_for(id)
         
@@ -91,6 +95,65 @@ class LegacyNPSFeedbackHandler(HandlerWithJSON):
 
         return self.send_json(status)
 
+    def do_PUT(self, path):
+        """
+        provide feedback on a particular DAP record
+        """
+        if not path:
+            return self.send_error_obj(405, "PUT not allowed",
+                                       "Cannot PUT to this resource without an ID")
+        id = path
+
+        try:
+            input = self.get_json_body()
+        except FatalError as ex:
+            return self.send_fatal_error(ex)
+
+        # check the input data
+        missing = [r for r in "phase systemID".split() if r not in input]
+        if missing:
+            return self.send_error_obj(400, "Bad Input",
+              f"Missing required propert{'ies' if len(missing) > 1 else 'y'} in input: {', '.join(missing)}")
+
+        if input.get('feedback') and \
+           not all(isinstance(f, Mapping) and f.get('description') for f in input['feedback']):
+            return self.send_error_obj(400, "Bad Input: feedback",
+                                       "feedback not a dictionary with at least a 'description' property")
+        if 'changesRequested' in input and not isinstance(input['changesRequested'], bool):
+            return self.send_error_obj(400, "Bad Input: changesRequested",
+                                       "changesRequested not a boolean")
+
+        try:
+            if input['phase'] == "canceled":
+                self._svc.cancel_external_review(id, self.system_name, str(input['systemID']),
+                                                 input.get('info_at'))
+            else:
+                if input['phase'] != "approved" or input.get('feedback'):
+                    if input['phase'] == "approved":
+                        input['changesRequested'] = False
+                    self._svc.apply_external_review(id, self.system_name, input['phase'], 
+                                                    str(input['systemID']), input.get('info_at'), 
+                                                    input.get('feedback'), input.get('changesRequested'))
+
+                if input['phase'] == "approved":
+                    self._svc.approve(id, self.system_name, str(input['systemID']), input.get('info_at'))
+
+            status = self._get_review_status_for(id)
+                
+        except ObjectNotFound as ex:
+            return self.send_error_obj(404, "ID Not Found", "No DAP record with requested ID")
+
+        except NotAuthorized as ex:
+            self.log.warning("%s: Premature review in progress? %s", id, str(ex))
+            return self.send_error_obj(401, "Not Authorized",
+                                       f"Record is not set to accept review feedback at this time")
+
+        except Exception as ex:
+            self.log.exception(ex)
+            return self.send_error_obj(500, "Server Error",
+                                       "Unexpected Server Error while accepting feedback")
+
+        return self.send_json(status)
 
     def do_GET(self, path, ashead=False):
 
@@ -119,7 +182,7 @@ class LegacyNPSFeedbackHandler(HandlerWithJSON):
             pass
             
         prec = self._svc.dbcli.get_record_for(id, dbio.ACLs.PUBLISH)  # may raise exc
-        rev = prec.status.get_review_from("nps1")
+        rev = prec.status.get_review_from(self.system_name)
         if not rev:
             rev = {}
         return rev
@@ -129,7 +192,7 @@ class LegacyNPSFeedbackHandler(HandlerWithJSON):
 
         out = []
         for prec in recs:
-            rev = prec.status.get_review_from("nps1")
+            rev = prec.status.get_review_from(self.system_name)
             if rev and rev.get('phase') != "approved":
                 out.append(rev)
 
@@ -167,6 +230,7 @@ class ExternalReviewApp(AuthenticatedWSGIApp):
         "fsbased":  dbio.FSBasedDBClientFactory,
         "mongo":    dbio.MongoDBClientFactory
     }
+    system_name = "nps1"
 
     def __init__(self, config: Mapping, dbio_client_factory: dbio.DBClientFactory=None, base_ep: str=None):
         log = deflog
@@ -176,7 +240,7 @@ class ExternalReviewApp(AuthenticatedWSGIApp):
         if config.get('base_ep_path'):
             baseep = config['base_ep_path']
         
-        super(ExternalReviewApp, self).__init__(config, log, baseep, "nps1")
+        super(ExternalReviewApp, self).__init__(config, log, baseep, self.system_name)
 
         if not dbio_client_factory:
             dbclsnm = self.cfg.get('dbio', {}).get('factory')

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -2815,6 +2815,9 @@ class DAPService(ProjectService):
         to shepherd the record through the review process.  Write access is revoked for users 
         that currently have it (saving who that is to an "_write" permission).  Curators and 
         reviewers will be given read access.
+
+        :param list[str] readers:  a list of user ids that should be given read access (can be 
+                                   None or an empty list)
         """
         if readers is None:
             readers = []
@@ -2862,10 +2865,10 @@ class DAPService(ProjectService):
         """
         for perm in [ACLs.ADMIN, ACLs.WRITE, ACLs.DELETE, ACLs.READ]:
             who = list(prec.acls.iter_perm_granted("_"+perm))
-            prec.acls.revoke_perm_from_all(perm)               # take out the reviewers
-            prec.acls.grant_perm_to(perm, *who)                # restore the original editors
+            prec.acls.revoke_perm_from_all(perm, _need_perm=ACLs.PUBLISH)  # take out the reviewers
+            prec.acls.grant_perm_to(perm, *who, _need_perm=ACLs.PUBLISH)   # restore the original editors
             if not for_review:
-                prec.acls.revoke_perm_from_all("_"+perm)
+                prec.acls.revoke_perm_from_all("_"+perm, _need_perm=ACLs.PUBLISH)
 
         # revoke update permissions in the file manager
         if self._fmcli:

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -2712,11 +2712,15 @@ class DAPService(ProjectService):
             _prec = self.dbcli.get_record_for(id, ACLs.ADMIN)
             version = _prec.data.get('version') or _prec.data.get('@version') or '1.0.0'
             try:
-                options["title"] = _prec.data.get("title")
-                options["description"] = "\n\n".join(_prec.data.get("description", []))
+                revopts = dict((k,v) for k,v in options.items()
+                                     if k in ["instructions", "changes", "reviewers", "security_review"])
+                revopts["title"] = _prec.data.get("title")
+                revopts["description"] = "\n\n".join(_prec.data.get("description", []))
                 if _prec.meta.get("software_included"):
-                    options["security_review"] = True
-                self._extrevcli.submit(_prec.id, self.who.actor, version, **options)
+                    revopts["security_review"] = True
+                if ':' in _prec.id:
+                    revopts["pubid"] = "ark:/" + const.ARK_NAAN + '/' + re.sub(r':', '-', _prec.id)
+                self._extrevcli.submit(_prec.id, self.who.actor, version, **revopts)
 
                 # refresh, in case the record has changed
                 _prec = self.dbcli.get_record_for(id, ACLs.READ)

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -2717,6 +2717,8 @@ class DAPService(ProjectService):
                 if _prec.meta.get("software_included"):
                     options["security_review"] = True
                 self._extrevcli.submit(_prec.id, self.who.actor, version, **options)
+                if self._extrevcli.system_name == "nps1":
+                    self.apply_external_review(_prec.id, self._extrevcli.system_name, "requested")
 
                 # refresh, in case the record has changed
                 _prec = self.dbcli.get_record_for(id, ACLs.READ)

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -313,6 +313,9 @@ class DAPService(ProjectService):
         self._mediatypes = None
         self._formatbyext = None
         self._extrevcli = extrevcli
+        if self._extrevcli and not getattr(self._extrevcli, 'people_service', None) and \
+           self.dbcli.people_service:
+            self._extrevcli.people_service = self.dbcli.people_service
 
         self._minnerdmver = minnerdmver
 

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -32,7 +32,7 @@ from ...dbio import (DBClient, DBClientFactory, ProjectRecord, AlreadyExists, No
                      ProjectService, ProjectServiceFactory, DAP_PROJECTS)
 from ...dbio.wsgi.project import (MIDASProjectApp, ProjectDataHandler, ProjectInfoHandler,
                                   ProjectSelectionHandler, ServiceApp)
-from ...dbio import status, ANONYMOUS, restore
+from ...dbio import status, ANONYMOUS, PUBLIC_GROUP, restore
 from ..review import DAPReviewer, DAPNERDmReviewValidator
 from ..extrev import ExternalReviewException, create_external_review_client
 from nistoar.base.config import ConfigurationException, merge_config
@@ -2807,7 +2807,7 @@ class DAPService(ProjectService):
 
         try:
             # reset permissions
-            self._set_review_permissions(prec)
+            self._set_review_permissions(prec, PUBLIC_GROUP)  # TODO: confine to assigned reviewers
             # don't save until submission process is complete
 
         except FileManagerException as ex:
@@ -2836,14 +2836,16 @@ class DAPService(ProjectService):
         """
         if readers is None:
             readers = []
+        elif isinstance(readers, str):
+            readers = [readers]
 
         # record away who has write access
-        for perm in [ ACLs.WRITE, ACLs.DELETE, ACLs.ADMIN, ACLs.READ ]:
-            if prec.status.state == status.EDIT or prec.status.state == status.READY or \
-               len(list(prec.acls.iter_perm_granted("_"+perm))) == 0:
-                who = list(prec.acls.iter_perm_granted(perm))
-                prec.acls.revoke_perm_from_all("_"+perm)
-                prec.acls.grant_perm_to("_"+perm, *who)
+        if len(list(prec.acls.iter_perm_granted(ACLs.PUBLISH))) == 0:
+            # a publishing/reviewing process is not currently engaged
+            for perm in [ ACLs.WRITE, ACLs.DELETE, ACLs.ADMIN, ACLs.READ ]:
+                if len(list(prec.acls.iter_perm_granted("_"+perm))) == 0:
+                    who = list(prec.acls.iter_perm_granted(perm))
+                    prec.acls.grant_perm_to("_"+perm, *who)
 
         # revoke update permissions in the file manager
         if self._fmcli:
@@ -2856,7 +2858,7 @@ class DAPService(ProjectService):
         # revoke permissions that can change the record
         prec.acls.revoke_perm_from_all(ACLs.WRITE)
         prec.acls.revoke_perm_from_all(ACLs.DELETE)
-        prec.acls.revoke_perm_from_all(ACLs.ADMIN)
+        prec.acls.revoke_perm_from_all(ACLs.ADMIN, False)
 
         # give PUBLISH permission to reviewer IDs
         if self.cfg.get("reviewer_ids"):
@@ -2878,11 +2880,16 @@ class DAPService(ProjectService):
                                  fully reset to the permissions as if going either to a published 
                                  state or a complete edit state (because publishing was canceled).
         """
-        for perm in [ACLs.ADMIN, ACLs.WRITE, ACLs.DELETE, ACLs.READ]:
-            who = list(prec.acls.iter_perm_granted("_"+perm))
-            prec.acls.revoke_perm_from_all(perm, _need_perm=ACLs.PUBLISH)  # take out the reviewers
-            prec.acls.grant_perm_to(perm, *who, _need_perm=ACLs.PUBLISH)   # restore the original editors
-            if not for_review:
+        if for_review:
+            # just give original writers their write permission
+            who = list(prec.acls.iter_perm_granted("_"+ACLs.WRITE))
+            prec.acls.grant_perm_to(ACLs.WRITE, *who, _need_perm=ACLs.PUBLISH)
+
+        else:
+            for perm in [ACLs.ADMIN, ACLs.WRITE, ACLs.DELETE, ACLs.READ]:
+                who = list(prec.acls.iter_perm_granted("_"+perm))
+                prec.acls.revoke_perm_from_all(perm, _need_perm=ACLs.PUBLISH)  # take out the reviewers
+                prec.acls.grant_perm_to(perm, *who, _need_perm=ACLs.PUBLISH)   # restore the original editors
                 prec.acls.revoke_perm_from_all("_"+perm, _need_perm=ACLs.PUBLISH)
 
         # revoke update permissions in the file manager

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -2709,7 +2709,7 @@ class DAPService(ProjectService):
         statusdata = super().submit(id, message, options, _prec)
 
         # We save actually sumbitting to the external review framework until after all our "paperwork"
-        # that is is part of submission is completed.  This avoids a run condition if the framework
+        # that is is part of submission is completed.  This avoids a race condition if the framework
         # responds quickly.
         if options.get('do_review') and not self._extrevcli:
             # Sorry, we can't start an external review if we don't have a client to its service
@@ -2728,7 +2728,15 @@ class DAPService(ProjectService):
                     revopts["security_review"] = True
                 if ':' in _prec.id:
                     revopts["pubid"] = "ark:/" + const.ARK_NAAN + '/' + re.sub(r':', '-', _prec.id)
-                self._extrevcli.submit(_prec.id, self.who.actor, version, **revopts)
+
+                # determine if we need to resubmit for a review already in progress
+                rev = _prec.status.get_review_from(self._extrevcli.system_name)
+                if not rev or rev.get('phase') not in ['requested', 'canceled']:
+                    # review not started
+                    self._extrevcli.submit(_prec.id, self.who.actor, version, **revopts)
+                elif rev.get('phase') == 'paused':
+                    # reviewer requested changes
+                    self._extrevcli.resubmit(_prec.id, **revopts)
 
                 # refresh, in case the record has changed
                 _prec = self.dbcli.get_record_for(id, ACLs.READ)
@@ -2805,9 +2813,12 @@ class DAPService(ProjectService):
             return status.ACCEPTED
 
         if self._extrevcli and options['do_review'] and self._extrevcli.system_name in [ "nps1" ]:
-            # mark review as requested as the legacy NPS will not respond immediately
-            # need to do this before changing permissions
-            self.apply_external_review(prec.id, self._extrevcli.system_name, "requested", _prec=prec)
+            # is the author responding to feedback from reviewers?
+            rev = prec.status.get_review_from(self._extrevcli.system_name)
+            if not rev:
+                # mark review as requested as the legacy NPS will not respond immediately
+                # need to do this before changing permissions
+                self.apply_external_review(prec.id, self._extrevcli.system_name, "requested", _prec=prec)
 
         try:
             # reset permissions

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -2729,7 +2729,7 @@ class DAPService(ProjectService):
                 _prec = self.dbcli.get_record_for(id, ACLs.READ)
 
             except ExternalReviewException as ex:
-                message = "Failed to submit to external review system: %s", str(ex)
+                message = "Failed to submit to external review system: " + str(ex)
                 self.log.error(message)
                 # possibly notify
                 _prec.status.set_state(status.UNWELL)

--- a/python/nistoar/midas/dap/service/mds3.py
+++ b/python/nistoar/midas/dap/service/mds3.py
@@ -31,7 +31,7 @@ from ...dbio import (DBClient, DBClientFactory, ProjectRecord, AlreadyExists, No
                      InvalidUpdate, ObjectNotFound, PartNotAccessible, NotEditable, DBIORecordException,
                      ProjectService, ProjectServiceFactory, DAP_PROJECTS)
 from ...dbio.wsgi.project import (MIDASProjectApp, ProjectDataHandler, ProjectInfoHandler,
-                                  ProjectSelectionHandler, ServiceApp)
+                                  ProjectSelectionHandler, ProjectStatusHandler, ServiceApp)
 from ...dbio import status, ANONYMOUS, PUBLIC_GROUP, restore
 from ..review import DAPReviewer, DAPNERDmReviewValidator
 from ..extrev import ExternalReviewException, create_external_review_client
@@ -2712,6 +2712,8 @@ class DAPService(ProjectService):
         # that is is part of submission is completed.  This avoids a run condition if the framework
         # responds quickly.
         if options.get('do_review') and not self._extrevcli:
+            # Sorry, we can't start an external review if we don't have a client to its service
+            # We just can't.  We won't.
             options['do_review'] = False
         if self._extrevcli and options.get('do_review'):
             # refresh the record
@@ -2778,6 +2780,8 @@ class DAPService(ProjectService):
         """
         if not self._extrevcli:
             self.log.warning("No External Review system configured to handle DAP records!")
+        if options is None:
+            options = {}
 
         version = prec.data.get('version') or prec.data.get('@version') or '1.0.0'
         needreview = version == '1.0.0'
@@ -2910,6 +2914,7 @@ class DAPService(ProjectService):
         canceling all reviews are either canceled or completed but is still in a SUBMITTED state, the 
         record will be returned to the EDIT state.  
         """
+        self.log.debug("%s: Canceling %s review", id, revsys)
         prec = super().cancel_external_review(id, revsys, revid, infourl) # m.r ObjectNotFound/NotAuthorized
         if prec.status.state == status.SUBMITTED:
             # change a SUBMITTED record back to full edit status (as if never submitted)
@@ -3310,3 +3315,20 @@ class DAPProjectSelectionHandler(ProjectSelectionHandler):
         for rec in self._dbcli.select_constraint_records(filter, perms):
             yield to_DAPRec(rec, self._fmcli)
 
+class DAPProjectStatusHandler(ProjectStatusHandler):
+    """
+    handle status requests and actions.  This provides some special handling of external review 
+    status access
+    """
+
+    def external_review_status(self, prjstatus, revname=None):
+
+        # If nps1, ask NPS to refresh the status 
+        if revname == "nps1" and self.svc.extrevcli and \
+           self.svc.extrevcli.system_name == "nps1" and self.svc.extrevcli.refresh_status():
+            prjstatus = self.svc.get_status(self._id)
+            
+        return super().external_review_status(prjstatus, revname)
+
+                
+            

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1538,7 +1538,7 @@ class DBClientFactory(ABC):
         :param dict          config:  the DBClient configuration (see the
                                       :py:mod:`dbio module documentation<nistoar.midas.dbio>` for 
                                       a description of the configuration schema)
-        :param PeoplService peopsvc:  a PeopleService to use to look up people in the organization.  If
+        :param PeopleService peopsvc:  a PeopleService to use to look up people in the organization.  If
                                       not provided, an attempt will be made to create one from the 
                                       configuration (via its ``people_service`` parameter). 
         :param DBIOClientNotifier notifier:  a DBIOClientNotifier to use for sending alerts to 

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1060,7 +1060,7 @@ class DBClient(ABC):
         """
         if self.name_exists(name, foruser or self.user_id):
             raise AlreadyExists(
-                "User {} has already defined a record with name={}".format(foruser, name))
+                "User {} has already defined a record with name={}".format(foruser or self.user_id, name))
 
         if foruser and foruser != self.user_id and self.user_id not in self._cfg.get("superusers", []) \
            and self._who.agent_class != Agent.ADMIN:

--- a/python/nistoar/midas/dbio/fsbased.py
+++ b/python/nistoar/midas/dbio/fsbased.py
@@ -283,7 +283,7 @@ class FSBasedDBClientFactory(base.DBClientFactory):
         """
         super(FSBasedDBClientFactory, self).__init__(config)
         if not dbroot:
-            dbroot = self.cfg.get("db_root_dir")
+            dbroot = self._cfg.get("db_root_dir")
             if not dbroot:
                 raise ConfigurationException("Missing required configuration parameter: db_root_dir")
         if not os.path.isdir(dbroot):

--- a/python/nistoar/midas/dbio/project.py
+++ b/python/nistoar/midas/dbio/project.py
@@ -1259,7 +1259,7 @@ class ProjectService(MIDASSystem):
 
         revmd = stat.pubreview(revsys, phase, revid, infourl, feedback, fbreplace, **extra_info)
         if not self._apply_external_review_updates(_prec, revmd, request_changes):
-            _prec.save(ACLs.PUBLISH)
+            _prec.save()
 
         msg = "external %s review phase in progress" % revsys
         if revmd.get('phase'):

--- a/python/nistoar/midas/dbio/project.py
+++ b/python/nistoar/midas/dbio/project.py
@@ -1245,7 +1245,7 @@ class ProjectService(MIDASSystem):
         :param list feedback:  a list of reviewer feedback.  If None, the previously saved feedback will 
                              be retained.  If an empty list and ``fbreplace`` is True (default), the 
                              previously save feedback will be dropped and replaced with an empty list.
-        :param boo request_changes:  if True, return this record to a state that allows the authors to 
+        :param bool request_changes:  if True, return this record to a state that allows the authors to 
                              make further edits.  (This would include changing the record state to 
                              "edit".)  This record must currently be in the "submitted" state, otherwise,
                              this parameter will be ignored.
@@ -1259,7 +1259,7 @@ class ProjectService(MIDASSystem):
 
         revmd = stat.pubreview(revsys, phase, revid, infourl, feedback, fbreplace, **extra_info)
         if not self._apply_external_review_updates(_prec, revmd, request_changes):
-            _prec.save()
+            _prec.save(ACLs.PUBLISH)
 
         msg = "external %s review phase in progress" % revsys
         if revmd.get('phase'):
@@ -1292,7 +1292,7 @@ class ProjectService(MIDASSystem):
         if self._sufficiently_reviewed(id, _prec=prec):
             self.log.info("%s: project is ready for publishing", id)
             prec.status.set_state(status.ACCEPTED)
-            prec.save()
+            prec.save(ACLs.PUBLISH)
 
             if publish:
                 self.publish(id)

--- a/python/nistoar/midas/dbio/project.py
+++ b/python/nistoar/midas/dbio/project.py
@@ -1321,7 +1321,7 @@ class ProjectService(MIDASSystem):
             revsys = [ revsys ]
 
         for sys in revsys:
-            self.apply_external_review(id, sys, "canceled", revid, infourl, feedback=[])
+            self.apply_external_review(id, sys, "canceled", revid, infourl, feedback=[], _prec=prec)
 
         return prec
 

--- a/python/nistoar/midas/dbio/status.py
+++ b/python/nistoar/midas/dbio/status.py
@@ -243,7 +243,9 @@ class RecordStatus:
         revs = self._data.get(_pubreview_p, {})
         if not revs.get(revsys):
             return None
-        return deepcopy(revs[revsys])
+        out = deepcopy(revs[revsys])
+        out['system'] = revsys
+        return out
 
     def get_review_phases(self) -> Mapping[str,str]:
         """

--- a/python/nistoar/midas/dbio/status.py
+++ b/python/nistoar/midas/dbio/status.py
@@ -304,6 +304,7 @@ class RecordStatus:
             pubrev['@id'] = id
         if infourl:
             pubrev['info_at'] = infourl
+        pubrev['updated'] = time()
 
         oldrev = self._data.get(_pubreview_p, {}).get(revsys, {})
         oldfb = oldrev.get('feedback', [])

--- a/python/nistoar/midas/dbio/status.py
+++ b/python/nistoar/midas/dbio/status.py
@@ -232,6 +232,14 @@ class RecordStatus:
             return "(not yet submitted)"
         return datetime.fromtimestamp(math.floor(self.submitted)).isoformat()
 
+    def get_review_systems(self) -> List[str]:
+        """
+        return a list of the review system names that the record has been submitted to.  
+
+        These are the systems that this status has data for.  
+        """
+        return list(self._data.get(_pubreview_p, {}).keys())
+
     def get_review_from(self, revsys: str) -> Mapping:
         """
         return the review data from the given system
@@ -246,6 +254,21 @@ class RecordStatus:
         out = deepcopy(revs[revsys])
         out['system'] = revsys
         return out
+
+    def delete_review_from(self, revsys: str) -> Mapping:
+        """
+        delete the review data from the given system (as if it never happened).
+        :param str revsys:  the name of the review system that is managing the review
+        :return:  the deleted review state data or None if the review from that system 
+                  has not yet been started.
+                  :rtype: Mapping
+        """
+        revs = self._data.get(_pubreview_p, {})
+        target = revs.get(revsys)
+        if not target:
+            return None
+        del revs[revsys]
+        return target
 
     def get_review_phases(self) -> Mapping[str,str]:
         """

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -1124,6 +1124,9 @@ class ProjectStatusHandler(ProjectRecordHandler):
             return self.send_error_resp(404, "ID not found",
                                         "Record with requested identifier not found", self._id, ashead=ashead)
 
+        if re.search(r'^external_review\b', path):
+            revname = '/'.join(path.split('/')[1:])
+            return self.external_review_status(out, path, self._id)
         if path == "state":
             out = out.state
         elif path == "action":
@@ -1211,6 +1214,19 @@ class ProjectStatusHandler(ProjectRecordHandler):
             return self.send_error_resp(409, "Not in editable state", "Record is not in state=edit or ready")
 
         return self.send_json(stat.to_dict())
+
+    def external_review_status(self, prjstatus, revname=None):
+        out = prjstatus.to_dict().get("external_review")
+        if not out:
+            return self.send_error_resp(404, "Not In Review",
+                                        "record has not been submitted for review, yet")
+        if revname:
+            if not out.get(revname):
+                return self.send_error_resp(404, "Not Reviewed",
+                                            f"record has not been submitted to {rename} for review, yet")
+            out = out[revname]
+
+        return self.send_json(out)
 
     def review(self, ashead=False):
         """

--- a/python/nistoar/pdr/exceptions.py
+++ b/python/nistoar/pdr/exceptions.py
@@ -22,7 +22,7 @@ class PDRWarning(OARWarning):
             msg = "Unspecified Warning"
         super(PDRWarning, self).__init__(msg, cause, pdrsys)
 
-class PDRException(Exception):
+class PDRException(OARException):
     """
     a base class for exceptions occuring in the PDR system
     """

--- a/python/nistoar/pdr/utils/cli.py
+++ b/python/nistoar/pdr/utils/cli.py
@@ -4,6 +4,8 @@ a module providing utility code for creating command-line interfaces to OAR syst
 import os, sys, logging
 from copy import deepcopy
 from argparse import ArgumentParser, HelpFormatter, SUPPRESS
+from typing import Mapping, Union
+from types import ModuleType
 
 from nistoar.pdr.exceptions import StateException
 from nistoar.base.config import ConfigurationException
@@ -11,7 +13,7 @@ from nistoar.base import config as cfgmod
 
 EXPLAIN=cfgmod.NORMAL
 
-def explain(log, message, *params):
+def explain(log: logging.Logger, message: str, *params):
     """
     log a message that is quieter than INFO but louder than DEBUG.  This is intended for messages 
     that should go into the log, but not necessarily to the terminal (unless --verbose was specified).
@@ -28,7 +30,7 @@ class _MyHelpFormatter(HelpFormatter):
             paras.append(super(_MyHelpFormatter, self)._fill_text(para, width, indent))
         return "\n\n".join(paras)
 
-def define_prog_opts(progname, description=None, epilog=None, parser=None):
+def define_prog_opts(progname: str, description: str=None, epilog: str=None, parser: ArgumentParser=None):
     """
     define the top level arguments for a script that will provide a suite of subcommands
 
@@ -90,7 +92,7 @@ class CommandFailure(Exception):
     Other exit codes greater than 10 may be used for more specified errors.  
     """
     
-    def __init__(self, cmdname, message, exstat=1, cause=None):
+    def __init__(self, cmdname: str, message: str, exstat: int=1, cause=None):
         """
         Create the exception
         :param str cmdname:   the name of the command that failed to execute
@@ -114,7 +116,7 @@ class CommandSuite(object):
     """
     an interface for running the sub-commands of a parent command
     """
-    def __init__(self, suitename, parent_parser, current_dests=None):
+    def __init__(self, suitename: str, parent_parser: ArgumentParser, current_dests=None):
         """
         create a command interface
         :param str suitename:  the command name used to access this suites' subcommands
@@ -135,7 +137,7 @@ class CommandSuite(object):
     def _register_parser_dests(self, parser):
         self._dests.update([a.dest for a in parser._actions])
 
-    def load_subcommand(self, cmdmod, cmdname=None):
+    def load_subcommand(self, cmdmod, cmdname: str=None):
         """
         load a subcommand into this suite of subcommands.  
 
@@ -174,7 +176,7 @@ class CommandSuite(object):
             else:
                 subparser.epilog = morehelp
 
-    def extract_config_for_cmd(self, config, cmdname, cmd=None):
+    def extract_config_for_cmd(self, config: Mapping, cmdname: str, cmd=None):
         """
         merge command-specific configuration with the top-level configuration.  The input config
         can contain a property ``cmd`` that holds configuration data that is specific to particular 
@@ -201,7 +203,7 @@ class CommandSuite(object):
 
         return out
 
-    def execute(self, args, config=None, log=None):
+    def execute(self, args, config: Mapping=None, log: logging.Logger=None):
         """
         execute a subcommand from this command suite
         :param argparse.Namespace args:  the parsed arguments
@@ -257,7 +259,7 @@ class CLISuite(CommandSuite):
         """
         return self.parser.parse_args(args)
 
-    def load_subcommand(self, cmdmod, cmdname=None, exit_offset=None):
+    def load_subcommand(self, cmdmod, cmdname: str=None, exit_offset: int=None):
         if not hasattr(cmdmod, "load_into"):
             raise StateException("command module/object has no load_into() function: " + repr(cmdmod))
         if not cmdname:
@@ -279,7 +281,7 @@ class CLISuite(CommandSuite):
                 subparser.epilog = morehelp
 
 
-    def configure_log(self, args, config):
+    def configure_log(self, args, config: Mapping):
         """
         set-up logging according to the command-line arguments and the given configuration.
         """
@@ -338,7 +340,7 @@ class CLISuite(CommandSuite):
             config = {}
         return config
                 
-    def execute(self, args, config=None):
+    def execute(self, args, config: Mapping=None):
         """
         execute the command given in the arguments
         :param list|object args:   the program arguments (including the command name).  Typically, 

--- a/python/nistoar/web/rest/base.py
+++ b/python/nistoar/web/rest/base.py
@@ -561,10 +561,10 @@ class WSGIApp(metaclass=ABCMeta):
             who = self.authenticate(env)
         except Unauthenticated as ex:
             self.log.debug("Authentication failure: %s", str(ex))
-            self.send_error(401, "Authentication Failure")
+            return Handler(path, env, start_resp).send_error(401, "Authentication Failure")
         except Exception as ex:
-            self.log.error("Unexpected failure while authenticating: %s", str(ex))
-            self.send_error(500, "Internal Server Error")
+            self.log.exception("Unexpected failure while authenticating: %s", str(ex))
+            return Handler(path, env, start_resp).send_error(500, "Internal Server Error")
 
         if self.base_ep:
             if path.startswith(self.base_ep):

--- a/python/nistoar/web/rest/base.py
+++ b/python/nistoar/web/rest/base.py
@@ -744,7 +744,7 @@ def authenticate_via_authkey(svcname: str, env: Mapping, authcfg: Mapping, log: 
 
     :param str   svcname: a name to provide as the agent software vehicle
     :param dict      env: the WSGI environment containing the request data
-    :param dict  authcfg: the JWT decoding configuration (see above)
+    :param dict  authcfg: the supported keys and user configuration (see above)
     :param Logger    log: the logger that can be used to record messages
     :param [str]  agents: an optional list of agent strings to attach to output agent
     :param str client_id: an ID representing the OAR client being used to connect.  If None,

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,7 +17,8 @@ CLASSIFIERS = [
 
 SCRIPTS = [
     'pdrhealthcheck.py', 'nsdsync.py', 'midasadm', 'pdr',
-    'resolver-uwsgi.py', 'pdp-uwsgi.py', 'midas-uwsgi.py', 'websocket_server.py', 'fm-uwsgi.py'
+    'resolver-uwsgi.py', 'pdp-uwsgi.py', 'midas-uwsgi.py', 'websocket_server.py', 'fm-uwsgi.py',
+    'npsfeedback-uwsgi.py'
 ]
 
 TESTSCRIPTS = [

--- a/python/tests/nistoar/midas/dap/cmd/test_get.py
+++ b/python/tests/nistoar/midas/dap/cmd/test_get.py
@@ -1,0 +1,161 @@
+"""
+test review subcommand module
+"""
+import os, sys, logging, argparse, pdb, time, json, shutil, tempfile
+import unittest as test
+from pathlib import Path
+
+from nistoar.pdr.utils import cli, read_json, write_json
+from nistoar.midas.dap.cmd import get, create_DAPService, get_agent
+from nistoar.base import config as cfgmod
+from nistoar.midas.dap.nerdstore.inmem import InMemoryResourceStorage
+from nistoar.midas.dbio.inmem import InMemoryDBClient
+from nistoar.midas.dbio.mongo import MongoDBClient
+from nistoar.midas.dbio.fsbased import FSBasedDBClient
+from nistoar.midas.dbio import status
+from nistoar.midas.dbio.project import NotSubmitable
+
+tmpdir = tempfile.TemporaryDirectory(prefix="_test_review.")
+testdir = Path(__file__).parents[0]
+
+try:
+    os.getlogin()
+    def getlogin():
+        return os.getlogin()
+except OSError as ex:
+    # this will happen if there is not controlling terminal
+    import pwd
+    def getlogin():
+        return pwd.getpwuid(os.getuid())[0]
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    rootlog = logging.getLogger()
+    rootlog.setLevel(logging.DEBUG)
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_review.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    loghdlr.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    rootlog.addHandler(loghdlr)
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    tmpdir.cleanup()
+
+class TestReviewCmd(test.TestCase):
+
+    def setUp(self):
+        self.cmd = cli.CLISuite("midasadm")
+        self.cmd.load_subcommand(get)
+
+        root = os.path.join(tmpdir.name, "dbfiles")
+        self.cfg = {
+            'dbio': {
+                "factory": "fsbased",
+                "db_root_dir": root,
+                "project_id_minting": {
+                    "default_shoulder": {
+                        "public": "mds3"
+                    }
+                }
+            },
+            'doi_naan': '10.88888',
+            'nerdstorage': {
+                'type': 'fsbased',
+                'store_dir': os.path.join(root, "nerdm")
+            }
+        }
+        self.log = logging.getLogger()
+        
+    def tearDown(self):
+        os.environ['LOGNAME'] = getlogin()
+        dapdir = os.path.join(tmpdir.name, "dbfiles")
+        if os.path.isdir(dapdir):
+            shutil.rmtree(dapdir)
+
+    def test_parse(self):
+        args = self.cmd.parse_args("-q get mds3:88888".split())
+        self.assertEqual(args.workdir, "")
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+        self.assertEqual(args.cmd, "get")
+        self.assertEqual(args.dbid, "mds3:88888")
+        self.assertEqual(args.prop, [])
+        self.assertFalse(args.outfile)
+        self.assertFalse(args.dosumm)
+
+        args = self.cmd.parse_args("-q get -s mds3:88888 data".split())
+        self.assertEqual(args.workdir, "")
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+        self.assertEqual(args.cmd, "get")
+        self.assertEqual(args.dbid, "mds3:88888")
+        self.assertEqual(args.prop, "data")
+        self.assertFalse(args.outfile)
+        self.assertTrue(args.dosumm)
+
+
+    def test_dbio_rec(self):
+        outfile = os.path.join(tmpdir.name, "out.json")
+#        self.assertFalse(os.path.exists(outfile))
+        args = self.cmd.parse_args(f"-q get mds3:0001 -o {outfile}".split())
+
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        rec = svc.create_record("goob", {"title": "Hello"})
+        self.assertEqual(rec.status.state, status.EDIT)
+
+        self.cmd.execute(args, self.cfg)
+
+        self.assertTrue(os.path.isfile(outfile))
+        rec = read_json(outfile)
+
+        self.assertEqual(rec.get('id'), 'mds3:0001')
+        self.assertEqual(rec.get('name'), 'goob')
+        self.assertIn('data', rec)
+        self.assertEqual(rec['data'].get('title'), 'Hello')
+        self.assertIn('status', rec)
+        self.assertNotIn('components', rec['data'])
+
+    
+
+    def test_data(self):
+        outfile = os.path.join(tmpdir.name, "out.json")
+#        self.assertFalse(os.path.exists(outfile))
+        args = self.cmd.parse_args(f"-q get mds3:0001 data -o {outfile}".split())
+
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        rec = svc.create_record("goob", {"title": "Hello"})
+        self.assertEqual(rec.data.get('title'), "Hello")
+        self.assertEqual(rec.status.state, status.EDIT)
+
+        self.cmd.execute(args, self.cfg)
+
+        self.assertTrue(os.path.isfile(outfile))
+        rec = read_json(outfile)
+
+        self.assertNotIn('id', rec)
+        self.assertNotIn('data', rec)
+        self.assertNotIn('status', rec)
+        self.assertIn('@id', rec)
+        self.assertEqual(rec.get('title'), 'Hello')
+        self.assertFalse(rec.get('components'))
+
+    
+        
+        
+
+        
+
+if __name__ == '__main__':
+    test.main()
+        

--- a/python/tests/nistoar/midas/dap/cmd/test_revperm.py
+++ b/python/tests/nistoar/midas/dap/cmd/test_revperm.py
@@ -1,0 +1,250 @@
+"""
+test review subcommand module
+"""
+import os, sys, logging, argparse, pdb, time, json, shutil, tempfile
+import unittest as test
+from pathlib import Path
+
+from nistoar.pdr.utils import cli, read_json, write_json
+from nistoar.midas.dap.cmd import revperm, create_DAPService, get_agent
+from nistoar.base import config as cfgmod
+from nistoar.midas.dap.nerdstore.inmem import InMemoryResourceStorage
+from nistoar.midas.dbio.inmem import InMemoryDBClient
+from nistoar.midas.dbio.mongo import MongoDBClient
+from nistoar.midas.dbio.fsbased import FSBasedDBClient
+from nistoar.midas.dbio import status
+from nistoar.midas.dbio.project import NotSubmitable
+
+tmpdir = tempfile.TemporaryDirectory(prefix="_test_revperm.")
+testdir = Path(__file__).parents[0]
+
+try:
+    os.getlogin()
+    def getlogin():
+        return os.getlogin()
+except OSError as ex:
+    # this will happen if there is not controlling terminal
+    import pwd
+    def getlogin():
+        return pwd.getpwuid(os.getuid())[0]
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    rootlog = logging.getLogger()
+    rootlog.setLevel(logging.DEBUG)
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_unsubmit.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    loghdlr.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    rootlog.addHandler(loghdlr)
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    tmpdir.cleanup()
+
+class TestRevpermCmd(test.TestCase):
+
+    def setUp(self):
+        self.cmd = cli.CLISuite("midasadm")
+        self.cmd.load_subcommand(revperm)
+
+        root = os.path.join(tmpdir.name, "dbfiles")
+        self.cfg = {
+            'dbio': {
+                "factory": "fsbased",
+                "db_root_dir": root,
+                "project_id_minting": {
+                    "default_shoulder": {
+                        "public": "mds3"
+                    }
+                }
+            },
+            'doi_naan': '10.88888',
+            'reviewer_ids': [ "greenlantern" ],
+            'external_review': {
+                "name": "simulated",
+                "nps_endpoint": "https://example.com/review",
+                "as_system": "nps1"
+            }
+        }
+        self.log = logging.getLogger()
+        
+    def tearDown(self):
+        os.environ['LOGNAME'] = getlogin()
+        dapdir = os.path.join(tmpdir.name, "dbfiles")
+        if os.path.isdir(dapdir):
+            shutil.rmtree(dapdir)
+
+    def test_parse(self):
+        args = self.cmd.parse_args("-q revperm mds2-88888 -U".split())
+        self.assertEqual(args.workdir, "")
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+        self.assertEqual(args.cmd, "revperm")
+        self.assertTrue(args.unset)
+        self.assertFalse(args.for_review)
+        self.assertEqual(args.readers, [])
+
+        args = self.cmd.parse_args("-q revperm mds2-88888 -r frodo,sam -r gollum".split())
+        self.assertEqual(args.workdir, "")
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+        self.assertEqual(args.cmd, "revperm")
+        self.assertFalse(args.unset)
+        self.assertFalse(args.for_review)
+        self.assertEqual(args.readers, "frodo,sam gollum".split())
+
+    def test_set_unset(self):
+        args = self.cmd.parse_args("-q revperm mds3:0001".split())
+
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        self.assertTrue(svc._extrevcli)
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("nps1"))
+        self.assertEqual(list(rec.acls.iter_perm_granted('read')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('write')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('admin')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('delete')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('publish')), [])
+
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor, "greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_write')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_admin')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_delete')), [who.actor])
+
+        args = self.cmd.parse_args("-q revperm mds3:0001 -u".split())
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor, "greenlantern"])
+        permitted = list(prec.acls.iter_perm_granted('write'))
+        self.assertIn(who.actor, permitted)
+        self.assertIn("greenlantern", permitted)
+        self.assertEqual(len(permitted), 2)
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), ["greenlantern"])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_write')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_admin')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_delete')), [])
+
+        # Return to review process
+        args = self.cmd.parse_args("-q revperm mds3:0001".split())
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor, "greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_write')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_admin')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_delete')), [who.actor])
+
+        # Complete review process
+        args = self.cmd.parse_args("-q revperm mds3:0001 -U".split())
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), [])
+        
+    def test_set_unset_with_readers(self):
+        args = self.cmd.parse_args("-q revperm mds3:0001 -r frodo,gollum".split())
+
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        self.assertTrue(svc._extrevcli)
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("nps1"))
+        self.assertEqual(list(rec.acls.iter_perm_granted('read')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('write')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('admin')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('delete')), [who.actor])
+        self.assertEqual(list(rec.acls.iter_perm_granted('publish')), [])
+
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor, "greenlantern",
+                                                                     "frodo", "gollum"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_write')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_admin')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_delete')), [who.actor])
+
+        args = self.cmd.parse_args("-q revperm mds3:0001 -u".split())
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor, "greenlantern",
+                                                                     "frodo", "gollum"])
+        permitted = list(prec.acls.iter_perm_granted('write'))
+        self.assertIn(who.actor, permitted)
+        self.assertIn("greenlantern", permitted)
+        self.assertEqual(len(permitted), 2)
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), ["greenlantern"])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_write')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_admin')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_delete')), [])
+
+        # Return to review process
+        args = self.cmd.parse_args("-q revperm mds3:0001".split())
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor, "greenlantern",
+                                                                     "frodo", "gollum"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), ["greenlantern"])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_write')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_admin')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('_delete')), [who.actor])
+
+        # Complete review process
+        args = self.cmd.parse_args("-q revperm mds3:0001 -U".split())
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertEqual(list(prec.acls.iter_perm_granted('read')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('admin')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('delete')), [who.actor])
+        self.assertEqual(list(prec.acls.iter_perm_granted('publish')), [])
+        
+        
+
+        
+
+
+if __name__ == '__main__':
+    test.main()

--- a/python/tests/nistoar/midas/dap/cmd/test_revreq.py
+++ b/python/tests/nistoar/midas/dap/cmd/test_revreq.py
@@ -1,0 +1,138 @@
+"""
+test review subcommand module
+"""
+import os, sys, logging, argparse, pdb, time, json, shutil, tempfile
+import unittest as test
+from pathlib import Path
+
+from nistoar.pdr.utils import cli, read_json, write_json
+from nistoar.midas.dap.cmd import revreq, create_DAPService, get_agent
+from nistoar.base import config as cfgmod
+from nistoar.midas.dap.nerdstore.inmem import InMemoryResourceStorage
+from nistoar.midas.dbio.inmem import InMemoryDBClient
+from nistoar.midas.dbio.mongo import MongoDBClient
+from nistoar.midas.dbio.fsbased import FSBasedDBClient
+from nistoar.midas.dbio import status
+from nistoar.midas.dbio.project import NotSubmitable
+
+tmpdir = tempfile.TemporaryDirectory(prefix="_test_review.")
+testdir = Path(__file__).parents[0]
+
+try:
+    os.getlogin()
+    def getlogin():
+        return os.getlogin()
+except OSError as ex:
+    # this will happen if there is not controlling terminal
+    import pwd
+    def getlogin():
+        return pwd.getpwuid(os.getuid())[0]
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    rootlog = logging.getLogger()
+    rootlog.setLevel(logging.DEBUG)
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_review.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    loghdlr.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    rootlog.addHandler(loghdlr)
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    tmpdir.cleanup()
+
+class TestReviewCmd(test.TestCase):
+
+    def setUp(self):
+        self.cmd = cli.CLISuite("midasadm")
+        self.cmd.load_subcommand(revreq)
+
+        root = os.path.join(tmpdir.name, "dbfiles")
+        self.cfg = {
+            'dbio': {
+                "factory": "fsbased",
+                "db_root_dir": root,
+                "project_id_minting": {
+                    "default_shoulder": {
+                        "public": "mds3"
+                    }
+                }
+            },
+            'doi_naan': '10.88888',
+            'external_review': {
+                "name": "simulated",
+                "nps_endpoint": "https://example.com/review"
+            }
+        }
+        self.log = logging.getLogger()
+        
+    def tearDown(self):
+        os.environ['LOGNAME'] = getlogin()
+        dapdir = os.path.join(tmpdir.name, "dbfiles")
+        if os.path.isdir(dapdir):
+            shutil.rmtree(dapdir)
+
+    def test_parse(self):
+        args = self.cmd.parse_args("-q revreq mds2-88888 -C mindata --change rmfile".split())
+        self.assertEqual(args.workdir, "")
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+        self.assertEqual(args.cmd, "revreq")
+        self.assertFalse(args.instruct)
+        self.assertFalse(args.markreq)
+        self.assertFalse(args.secrev)
+        self.assertFalse(args.nosecrev)
+        self.assertEqual(args.changes, ["mindata", "rmfile"])
+        self.assertIsNone(args.server)
+        self.assertIsNone(args.sysname)
+
+    def test_create(self):
+        args = self.cmd.parse_args("-q revreq mds3:0001".split())
+
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+
+        self.assertTrue(svc._extrevcli)
+        
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("sim"))
+        
+        prec = svc.get_record("mds3:0001")
+        self.assertTrue(prec)
+        self.assertEqual(rec.id, prec.id)
+
+    def test_apply(self):
+        args = self.cmd.parse_args("-q revreq mds3:0001 -C newrec -r".split())
+
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("sim"))
+
+        self.cmd.execute(args, self.cfg)
+
+        prec = svc.get_record(rec.id)
+        rev = prec.status.get_review_from("simulated")
+        self.assertTrue(rev)
+
+        
+        
+        
+
+
+        
+
+
+if __name__ == '__main__':
+    test.main()

--- a/python/tests/nistoar/midas/dap/cmd/test_unsubmit.py
+++ b/python/tests/nistoar/midas/dap/cmd/test_unsubmit.py
@@ -1,0 +1,211 @@
+"""
+test review subcommand module
+"""
+import os, sys, logging, argparse, pdb, time, json, shutil, tempfile
+import unittest as test
+from pathlib import Path
+
+from nistoar.pdr.utils import cli, read_json, write_json
+from nistoar.midas.dap.cmd import unsubmit, create_DAPService, get_agent
+from nistoar.base import config as cfgmod
+from nistoar.midas.dap.nerdstore.inmem import InMemoryResourceStorage
+from nistoar.midas.dbio.inmem import InMemoryDBClient
+from nistoar.midas.dbio.mongo import MongoDBClient
+from nistoar.midas.dbio.fsbased import FSBasedDBClient
+from nistoar.midas.dbio import status
+from nistoar.midas.dbio.project import NotSubmitable
+
+tmpdir = tempfile.TemporaryDirectory(prefix="_test_unsubmit.")
+testdir = Path(__file__).parents[0]
+
+try:
+    os.getlogin()
+    def getlogin():
+        return os.getlogin()
+except OSError as ex:
+    # this will happen if there is not controlling terminal
+    import pwd
+    def getlogin():
+        return pwd.getpwuid(os.getuid())[0]
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    rootlog = logging.getLogger()
+    rootlog.setLevel(logging.DEBUG)
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_unsubmit.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    loghdlr.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    rootlog.addHandler(loghdlr)
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    tmpdir.cleanup()
+
+class TestReviewCmd(test.TestCase):
+
+    def setUp(self):
+        self.cmd = cli.CLISuite("midasadm")
+        self.cmd.load_subcommand(unsubmit)
+
+        root = os.path.join(tmpdir.name, "dbfiles")
+        self.cfg = {
+            'dbio': {
+                "factory": "fsbased",
+                "db_root_dir": root,
+                "project_id_minting": {
+                    "default_shoulder": {
+                        "public": "mds3"
+                    }
+                }
+            },
+            'doi_naan': '10.88888',
+            'external_review': {
+                "name": "simulated",
+                "nps_endpoint": "https://example.com/review",
+                "as_system": "nps1"
+            }
+        }
+        self.log = logging.getLogger()
+        
+    def tearDown(self):
+        os.environ['LOGNAME'] = getlogin()
+        dapdir = os.path.join(tmpdir.name, "dbfiles")
+        if os.path.isdir(dapdir):
+            shutil.rmtree(dapdir)
+
+    def test_parse(self):
+        args = self.cmd.parse_args("-q unsubmit mds2-88888 -c simulated -f nps1".split())
+        self.assertEqual(args.workdir, "")
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+        self.assertEqual(args.cmd, "unsubmit")
+        self.assertFalse(args.forgetall)
+        self.assertEqual(args.forget, "nps1")
+        self.assertEqual(args.cancel, "simulated")
+
+    def test_reset(self):
+        args = self.cmd.parse_args("-q unsubmit mds3:0001".split())
+        
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        self.assertTrue(svc._extrevcli)
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("nps1"))
+
+        svc.submit(rec.id)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.SUBMITTED)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev.get('phase'), 'requested')
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_write')), [])
+
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.EDIT)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev.get('phase'), 'requested')
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('write')), [])
+
+    def test_cancel(self):
+        args = self.cmd.parse_args("-q unsubmit mds3:0001 -c nps1".split())
+        
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        self.assertTrue(svc._extrevcli)
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("nps1"))
+
+        svc.submit(rec.id)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.SUBMITTED)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev.get('phase'), 'requested')
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_write')), [])
+
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev.get('phase'), 'canceled')
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('write')), [])
+
+
+    def test_forget(self):
+        args = self.cmd.parse_args("-q unsubmit mds3:0001 -f nps1".split())
+        
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        self.assertTrue(svc._extrevcli)
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("nps1"))
+
+        svc.submit(rec.id)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.SUBMITTED)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev.get('phase'), 'requested')
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_write')), [])
+
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNone(rev)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('write')), [])
+
+    def test_forget_all(self):
+        args = self.cmd.parse_args("-q unsubmit -F mds3:0001".split())
+        
+        who = get_agent(args, self.cfg)
+        svc = create_DAPService(who, args, self.cfg, self.log)
+        self.assertTrue(svc._extrevcli)
+        rec = svc.create_record("goob")
+        self.assertEqual(rec.status.state, status.EDIT)
+        self.assertIsNone(rec.status.get_review_from("nps1"))
+
+        svc.submit(rec.id)
+        prec = svc.get_record(rec.id)
+        self.assertEqual(prec.status.state, status.SUBMITTED)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev.get('phase'), 'requested')
+        self.assertEqual(list(prec.acls.iter_perm_granted('write')), [])
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('_write')), [])
+
+        self.cmd.execute(args, self.cfg)
+        prec = svc.get_record(rec.id)
+        rev = prec.status.get_review_from("nps1")
+        self.assertIsNone(rev)
+        self.assertEqual(prec.status.state, status.EDIT)
+        self.assertNotEqual(list(prec.acls.iter_perm_granted('write')), [])
+
+        
+        
+        
+
+
+        
+
+
+if __name__ == '__main__':
+    test.main()

--- a/python/tests/nistoar/midas/dap/extrev/test_nps1.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_nps1.py
@@ -110,7 +110,7 @@ class TestNPSExternalReviewClient(test.TestCase):
         # Check that requests.post was called with expected headers and payload
         args, kwargs = mock_post.call_args
         url = args[0]
-        self.assertTrue(url.endswith("/review/1"))
+        self.assertTrue(url.endswith("/DataSet/SubmitDataset/1"))
         headers = kwargs["headers"]
         self.assertEqual(headers["Authorization"], "Bearer token123")
         self.assertEqual(headers["Content-Type"], "application/json")

--- a/python/tests/nistoar/midas/dap/extrev/test_nps1.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_nps1.py
@@ -1,6 +1,7 @@
 import unittest as test
 from unittest.mock import patch, MagicMock
 import json
+from copy import deepcopy
 
 from nistoar.midas.dap.extrev.nps1 import NPSExternalReviewClient
 from nistoar.midas.dap.extrev import ExternalReviewException
@@ -8,13 +9,13 @@ from nistoar.base.config import ConfigurationException
 
 # Example reviewers
 OWNER = {
-    "nistId": "900123",
+    "nistId": 900123,
     "firstName": "Isaac",
     "lastName": "Newton",
     "eMail": "Isaac.Newton@nist.gov"
 }
 TECH1 = {
-    "nistId": "900124",
+    "nistId": 900124,
     "firstName": "Alan",
     "lastName": "Turing",
     "eMail": "alan.turing@nist.gov"
@@ -133,11 +134,11 @@ class TestNPSExternalReviewClient(test.TestCase):
 
         res = cli.submit(
             id="X12",
-            submitter="OWNERX12"
+            submitter=123
         )
         payload = json.loads(mock_post.call_args[1]["data"])
-        self.assertEqual(payload["submitterID"], "OWNERX12")
-        self.assertEqual(payload["reviewers"][0]["nistId"], "OWNERX12")
+        self.assertEqual(payload["submitterID"], 123)
+        self.assertEqual(payload["reviewers"][0]["nistId"], 123)
         self.assertEqual(payload["reviewers"][0]["contactTypeId"], 7)
 
     # submit: no token
@@ -155,7 +156,7 @@ class TestNPSExternalReviewClient(test.TestCase):
         mock_post.return_value = fake_response(status=401, reason="Unauthorized")
         cli = NPSExternalReviewClient(GOOD_CFG)
         with self.assertRaises(ExternalReviewException) as cm:
-            cli.submit(id="RECFAIL", submitter="X")
+            cli.submit(id="RECFAIL", submitter=123)
         self.assertIn("Unauthorized", str(cm.exception))
 
     # submit: http 403 forbidden
@@ -165,7 +166,7 @@ class TestNPSExternalReviewClient(test.TestCase):
         mock_post.return_value = fake_response(status=403, reason="Forbidden")
         cli = NPSExternalReviewClient(GOOD_CFG)
         with self.assertRaises(ExternalReviewException) as cm:
-            cli.submit(id="RECFORBID", submitter="X")
+            cli.submit(id="RECFORBID", submitter=123)
         self.assertIn("Forbidden", str(cm.exception))
 
     # submit: http 500 (other error)
@@ -175,7 +176,7 @@ class TestNPSExternalReviewClient(test.TestCase):
         mock_post.return_value = fake_response(status=500, reason="Internal Server Error", json_data={"error": "fail"})
         cli = NPSExternalReviewClient(GOOD_CFG)
         with self.assertRaises(ExternalReviewException) as cm:
-            cli.submit(id="RECSERVER", submitter="X")
+            cli.submit(id="RECSERVER", submitter=123)
         self.assertIn("NPS API error", str(cm.exception))
         self.assertIn("Internal Server Error", str(cm.exception))
 
@@ -185,7 +186,7 @@ class TestNPSExternalReviewClient(test.TestCase):
     def test_submit_requests_error(self, mock_token, mock_post):
         cli = NPSExternalReviewClient(GOOD_CFG)
         with self.assertRaises(ExternalReviewException) as cm:
-            cli.submit(id="RECNETERR", submitter="X")
+            cli.submit(id="RECNETERR", submitter=123)
         self.assertIn("Failed to POST to NPS", str(cm.exception))
 
     # submit: people service used to look up submitter
@@ -196,29 +197,30 @@ class TestNPSExternalReviewClient(test.TestCase):
         ps = MagicMock()
         ps.get_person_by_eid.return_value = {
             "peopleID": "123987",
-            "nistUsername": "jld1",
+            "nistUsername": "drj2",
             "firstName": "Diogo",
             "lastName": "Jota",
             "emailAddress": "diogo.jota@nist.gov"
         }
+        ps.get_person.return_value = deepcopy(ps.get_person_by_eid.return_value)
 
         cli = NPSExternalReviewClient(GOOD_CFG, peopsvc=ps)
 
         mock_post.return_value = fake_response(json_data={"done": True})
-        result = cli.submit(id="PSTEST1", submitter="jld1")
+        result = cli.submit(id="PSTEST1", submitter="drj2")
 
         # Ensure get_person was called with the submitter ID
-        ps.get_person_by_eid.assert_called_once_with("jld1")
+        ps.get_person_by_eid.assert_called_once_with("drj2")
 
         # The reviewer info in the payload must match what the PeopleService returned
         payload = json.loads(mock_post.call_args[1]["data"])
         reviewer = payload["reviewers"][0]
-        assert reviewer["nistId"] == "jld1"
+        assert reviewer["nistId"] == "123987"
         assert reviewer["firstName"] == "Diogo"
         assert reviewer["lastName"] == "Jota"
         assert reviewer["eMail"] == "diogo.jota@nist.gov"
         assert reviewer["contactTypeId"] == 7  # Owner
-        assert payload["submitterID"] == "jld1"
+        assert payload["submitterID"] == "123987"
         assert result == {"done": True}
 
 

--- a/python/tests/nistoar/midas/dap/extrev/test_nps1.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_nps1.py
@@ -93,7 +93,7 @@ class TestNPSExternalReviewClient(test.TestCase):
         cli = NPSExternalReviewClient(GOOD_CFG)
 
         result = cli.submit(
-            id="REC001",
+            id="REC:001",
             submitter=OWNER["nistId"],
             title="A Test Title",
             description="Test Description",
@@ -110,14 +110,14 @@ class TestNPSExternalReviewClient(test.TestCase):
         # Check that requests.post was called with expected headers and payload
         args, kwargs = mock_post.call_args
         url = args[0]
-        self.assertTrue(url.endswith("/review/REC001"))
+        self.assertTrue(url.endswith("/review/1"))
         headers = kwargs["headers"]
         self.assertEqual(headers["Authorization"], "Bearer token123")
         self.assertEqual(headers["Content-Type"], "application/json")
 
         payload = json.loads(kwargs["data"])
         # DataSetID and reviewer list
-        self.assertEqual(payload["dataSetID"], "REC001")
+        self.assertEqual(payload["dataSetID"], 1)
         self.assertEqual(payload["reviewers"][0]["contactTypeId"], 7)
         self.assertEqual(payload["reviewers"][1]["contactTypeId"], 21)
         self.assertEqual(payload["instructions"], ["Do something extra"])

--- a/python/tests/nistoar/midas/dap/extrev/test_nps1.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_nps1.py
@@ -194,30 +194,31 @@ class TestNPSExternalReviewClient(test.TestCase):
     def test_submit_uses_people_service(self, mock_token, mock_post):
         # Prepare a mock PeopleService
         ps = MagicMock()
-        ps.get_person.return_value = {
-            "nistId": "123987",
+        ps.get_person_by_eid.return_value = {
+            "peopleID": "123987",
+            "nistUsername": "jld1",
             "firstName": "Diogo",
             "lastName": "Jota",
-            "eMail": "diogo.jota@nist.gov"
+            "emailAddress": "diogo.jota@nist.gov"
         }
 
         cli = NPSExternalReviewClient(GOOD_CFG, peopsvc=ps)
 
         mock_post.return_value = fake_response(json_data={"done": True})
-        result = cli.submit(id="PSTEST1", submitter="123987")
+        result = cli.submit(id="PSTEST1", submitter="jld1")
 
         # Ensure get_person was called with the submitter ID
-        ps.get_person.assert_called_once_with("123987")
+        ps.get_person_by_eid.assert_called_once_with("jld1")
 
         # The reviewer info in the payload must match what the PeopleService returned
         payload = json.loads(mock_post.call_args[1]["data"])
         reviewer = payload["reviewers"][0]
-        assert reviewer["nistId"] == "123987"
+        assert reviewer["nistId"] == "jld1"
         assert reviewer["firstName"] == "Diogo"
         assert reviewer["lastName"] == "Jota"
         assert reviewer["eMail"] == "diogo.jota@nist.gov"
         assert reviewer["contactTypeId"] == 7  # Owner
-        assert payload["submitterID"] == "123987"
+        assert payload["submitterID"] == "jld1"
         assert result == {"done": True}
 
 

--- a/python/tests/nistoar/midas/dap/extrev/test_nps1.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_nps1.py
@@ -86,11 +86,16 @@ class TestNPSExternalReviewClient(test.TestCase):
         self.assertIn("XYZ789", pub_url2)
 
     # submit: success, all required fields
+    @patch("nistoar.midas.dap.extrev.nps1.requests.get")
     @patch("nistoar.midas.dap.extrev.nps1.requests.post")
     @patch("nistoar.midas.dap.extrev.nps1.get_nsd_auth_token")
-    def test_submit_success(self, mock_token, mock_post):
+    def test_submit_success(self, mock_token, mock_post, mock_get):
         mock_token.return_value = "token123"
         mock_post.return_value = fake_response(json_data={"result": "OK"})
+        mock_get.return_value = fake_response(json_data=[{
+            "submitterID": 123,
+            "phase": "in progress"
+        }])
         cli = NPSExternalReviewClient(GOOD_CFG)
 
         result = cli.submit(
@@ -106,7 +111,7 @@ class TestNPSExternalReviewClient(test.TestCase):
         )
 
         # Response returned
-        self.assertEqual(result, {"result": "OK"})
+        self.assertEqual(result.get('phase'), "in progress")
 
         # Check that requests.post was called with expected headers and payload
         args, kwargs = mock_post.call_args
@@ -125,11 +130,16 @@ class TestNPSExternalReviewClient(test.TestCase):
         self.assertEqual(payload["reviewReason"], "Data change (major)")
 
     # submit: no reviewers provided, fallback owner
+    @patch("nistoar.midas.dap.extrev.nps1.requests.get")
     @patch("nistoar.midas.dap.extrev.nps1.requests.post")
     @patch("nistoar.midas.dap.extrev.nps1.get_nsd_auth_token")
-    def test_submit_fallback_owner(self, mock_token, mock_post):
+    def test_submit_fallback_owner(self, mock_token, mock_post, mock_get):
         mock_token.return_value = "tok"
         mock_post.return_value = fake_response(json_data={"ok": True})
+        mock_get.return_value = fake_response(json_data=[{
+            "submitterID": 123,
+            "phase": "in progress"
+        }])
         cli = NPSExternalReviewClient(GOOD_CFG)
 
         res = cli.submit(
@@ -190,9 +200,10 @@ class TestNPSExternalReviewClient(test.TestCase):
         self.assertIn("Failed to POST to NPS", str(cm.exception))
 
     # submit: people service used to look up submitter
+    @patch("nistoar.midas.dap.extrev.nps1.requests.get")
     @patch("nistoar.midas.dap.extrev.nps1.requests.post")
     @patch("nistoar.midas.dap.extrev.nps1.get_nsd_auth_token", return_value="TTT")
-    def test_submit_uses_people_service(self, mock_token, mock_post):
+    def test_submit_uses_people_service(self, mock_token, mock_post, mock_get):
         # Prepare a mock PeopleService
         ps = MagicMock()
         ps.get_person_by_eid.return_value = {
@@ -206,6 +217,10 @@ class TestNPSExternalReviewClient(test.TestCase):
 
         cli = NPSExternalReviewClient(GOOD_CFG, peopsvc=ps)
 
+        mock_get.return_value = fake_response(json_data=[{
+            "submitterID": 123,
+            "phase": "in progress"
+        }])
         mock_post.return_value = fake_response(json_data={"done": True})
         result = cli.submit(id="PSTEST1", submitter="drj2")
 
@@ -215,13 +230,13 @@ class TestNPSExternalReviewClient(test.TestCase):
         # The reviewer info in the payload must match what the PeopleService returned
         payload = json.loads(mock_post.call_args[1]["data"])
         reviewer = payload["reviewers"][0]
-        assert reviewer["nistId"] == "123987"
-        assert reviewer["firstName"] == "Diogo"
-        assert reviewer["lastName"] == "Jota"
-        assert reviewer["eMail"] == "diogo.jota@nist.gov"
-        assert reviewer["contactTypeId"] == 7  # Owner
-        assert payload["submitterID"] == "123987"
-        assert result == {"done": True}
+        self.assertEqual(reviewer["nistId"], "123987")
+        self.assertEqual(reviewer["firstName"], "Diogo")
+        self.assertEqual(reviewer["lastName"], "Jota")
+        self.assertEqual(reviewer["eMail"], "diogo.jota@nist.gov")
+        self.assertEqual(reviewer["contactTypeId"], 7)  # Owner
+        self.assertEqual(payload["submitterID"], "123987")
+        self.assertEqual(result.get('phase'), 'in progress')
 
 
 if __name__ == '__main__':

--- a/python/tests/nistoar/midas/dap/extrev/test_nps1.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_nps1.py
@@ -110,7 +110,7 @@ class TestNPSExternalReviewClient(test.TestCase):
         # Check that requests.post was called with expected headers and payload
         args, kwargs = mock_post.call_args
         url = args[0]
-        self.assertTrue(url.endswith("/DataSet/SubmitDataset/1"))
+        self.assertTrue(url.endswith("/DataSet/SubmitDataset"))
         headers = kwargs["headers"]
         self.assertEqual(headers["Authorization"], "Bearer token123")
         self.assertEqual(headers["Content-Type"], "application/json")

--- a/python/tests/nistoar/midas/dap/extrev/test_nps1_fbcli.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_nps1_fbcli.py
@@ -1,0 +1,191 @@
+import json, sys, os, logging, tempfile, time
+import unittest as test
+from unittest.mock import patch, MagicMock
+from copy import deepcopy
+from pathlib import Path
+from subprocess import Popen
+
+from nistoar.midas.dap.extrev.nps1 import ExternalReviewFeedbackClient
+from nistoar.midas.dap.extrev import ExternalReviewException
+from nistoar.base.config import ConfigurationException
+
+testdir = Path(__file__).parents[0]
+testserver = testdir / "testfb_server.py"
+tmpdir = tempfile.TemporaryDirectory(prefix="_nps1_fbcli.")
+
+PORT = 9990
+RECID = "mds3:0001"
+
+# uwsgi_opts = "--plugin python3"
+uwsgi_opts = ""
+if os.environ.get("OAR_UWSGI_OPTS") is not None:
+    uwsgi_opts = os.environ['OAR_UWSGI_OPTS']
+
+def startService(workdir):
+    pidfile = os.path.join(workdir, "testfb-server.pid")
+    logfile = os.path.join(workdir, "testfb-server.log")
+    wpy = os.path.join(testdir, "testfb_uwsgi.py")
+    cmd = f"uwsgi --daemonize {logfile} {uwsgi_opts} --http-socket :{PORT} --wsgi-file {wpy} --pidfile {pidfile} --set-ph workdir={workdir}"
+    os.system(cmd)
+    time.sleep(0.5)
+
+def stopService(workdir):
+    pidfile = os.path.join(workdir, "testfb-server.pid")
+    cmd = f"uwsgi --stop {pidfile}"
+    os.system(cmd)
+    time.sleep(1)
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global tmpdir
+    global loghdlr
+    global rootlog
+    rootlog = logging.getLogger()
+    rootlog.setLevel(logging.DEBUG)
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_feedback.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    loghdlr.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    rootlog.addHandler(loghdlr)
+    startService(tmpdir.name)
+
+def tearDownModule():
+    global tmpdir
+    global loghdlr
+    stopService(tmpdir.name)
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    tmpdir.cleanup()
+    
+
+class TestExternalReviewFeedbackClient(test.TestCase):
+
+    def setUp(self):
+        self.cfg = {
+            "service_endpoint": f"http://localhost:{PORT}/nps/leg/",
+            "auth_key": "secret"
+        }
+        self.cli = ExternalReviewFeedbackClient(self.cfg)
+
+    def tearDown(self):
+        self.cli.send_feedback(RECID, "requested", info_url='')
+
+    def test_get_review(self):
+        rev = self.cli.get_review(RECID)
+        self.assertTrue(isinstance(rev, dict))
+        self.assertEqual(rev['phase'], 'requested')
+        self.assertEqual(rev['system'], 'nps1')
+#        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+        self.assertNotIn('feedback', rev)
+
+    def test_cancel(self):
+        rev = self.cli.cancel(RECID)
+        self.assertTrue(isinstance(rev, dict))
+        self.assertEqual(rev['phase'], 'canceled')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+
+        rev = self.cli.get_review(RECID)
+        self.assertEqual(rev['phase'], 'canceled')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+
+    def test_send_feedback_info_url(self):
+        rev = self.cli.send_feedback(RECID, 'technical', info_url="https://nps.example.com/nps/1")
+        self.assertEqual(rev['phase'], 'technical')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertEqual(rev['info_at'], 'https://nps.example.com/nps/1')
+
+        rev = self.cli.get_review(RECID)
+        self.assertEqual(rev['phase'], 'technical')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertEqual(rev['info_at'], 'https://nps.example.com/nps/1')
+        
+        rev = self.cli.send_feedback(RECID, 'division', info_url='')
+        self.assertEqual(rev['phase'], 'division')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertEqual(rev['info_at'], 'https://nps.example.com/nps/1')
+
+    def test_send_feedback_feedback(self):
+        fb = {
+            "reviewer": "el techno",
+            "type": "comment",
+            "description": "this makes me feel sad."
+        }
+        rev = self.cli.send_feedback(RECID, 'technical', fb)
+        self.assertEqual(rev['phase'], 'technical')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+        self.assertTrue(rev.get('feedback'), fb)
+
+        rev = self.cli.get_review(RECID)
+        self.assertEqual(rev['phase'], 'technical')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+        self.assertTrue(rev.get('feedback'), fb)
+
+        fb = [ fb, {
+            "reviewer": "peanut gallery",
+            "type": "warn",
+            "description": "This will never sell."
+        }]
+        rev = self.cli.send_feedback(RECID, 'technical', fb)
+        self.assertEqual(rev['phase'], 'technical')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+        self.assertTrue(rev.get('feedback'), fb)
+
+        rev = self.cli.send_feedback(RECID, 'division')
+        self.assertEqual(rev['phase'], 'division')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+        self.assertTrue(rev.get('feedback'), fb)
+
+        rev = self.cli.send_feedback(RECID, 'ou', request_changes=True)
+        self.assertEqual(rev['phase'], 'ou')
+        self.assertEqual(rev['system'], 'nps1')
+        self.assertEqual(rev['@id'], '1')
+        self.assertTrue(rev['updated'])
+        self.assertNotIn('info_at', rev)
+        self.assertTrue(rev.get('feedback'), fb)
+
+        
+
+
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    test.main()
+
+
+    

--- a/python/tests/nistoar/midas/dap/extrev/test_sim.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_sim.py
@@ -25,7 +25,7 @@ class TestSimulatedExternalReviewClient(test.TestCase):
         self.assertEqual(revcli.projs, {})
 
         revcli = sim.SimulatedExternalReviewClient(self.cfg)
-        self.assertTrue(revcli.autoapp)
+        self.assertFalse(revcli.autoapp)
         self.assertIsNone(revcli.projsvc)
         self.assertEqual(revcli.projs, {})
 
@@ -46,7 +46,7 @@ class TestSimulatedExternalReviewClient(test.TestCase):
         with self.assertRaises(sim.ExternalReviewException):
             revcli.submit(id, "goober")
 
-        revcli = sim.SimulatedExternalReviewClient(self.cfg)
+        revcli = sim.SimulatedExternalReviewClient(self.cfg, True)
         revcli.submit(id, "adm", "1.0.1", instructions="keep it")
         self.assertIn(id, revcli.projs)
         self.assertEqual(revcli.projs[id]['submitter'], 'adm')

--- a/python/tests/nistoar/midas/dap/extrev/test_wsgi.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_wsgi.py
@@ -1,0 +1,232 @@
+"""
+test review subcommand module
+"""
+import os, sys, logging, argparse, pdb, time, json, shutil, tempfile
+import unittest as test
+from pathlib import Path
+from copy import deepcopy
+from collections import OrderedDict
+from io import StringIO
+
+from nistoar.midas.dap.extrev import wsgi
+from nistoar.midas.dap.service import mds3
+from nistoar.base import config as cfgmod
+from nistoar.midas.dap.nerdstore.inmem import InMemoryResourceStorage
+from nistoar.midas.dbio.inmem import InMemoryDBClient
+from nistoar.midas.dbio.mongo import MongoDBClient
+from nistoar.midas.dbio.fsbased import FSBasedDBClient
+from nistoar.midas.dbio import status
+from nistoar.pdr.utils.prov import Agent
+
+tmpdir = tempfile.TemporaryDirectory(prefix="_test_review.")
+testdir = Path(__file__).parents[0]
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    rootlog = logging.getLogger()
+    rootlog.setLevel(logging.DEBUG)
+    loghdlr = logging.FileHandler(os.path.join(tmpdir.name,"test_review.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    loghdlr.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    rootlog.addHandler(loghdlr)
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    tmpdir.cleanup()
+
+datadir = os.path.join(tmpdir.name, "dbfiles")
+
+class TestLegacyNPSFeedbackHandler(test.TestCase):
+
+    def start(self, status, headers=None, extup=None):
+        self.resp.append(status)
+        for head in headers:
+            self.resp.append("{0}: {1}".format(head[0], head[1]))
+
+    def body2dict(self, body):
+        return json.loads("\n".join(self.tostr(body)), object_pairs_hook=OrderedDict)
+
+    def tostr(self, resplist):
+        return [e.decode() for e in resplist]
+
+    def setUp(self):
+        self.cfg = {
+            'dbio': {
+                "factory": "fsbased",
+                "db_root_dir": datadir,
+                "project_id_minting": {
+                    "default_shoulder": {
+                        "public": "mds3"
+                    }
+                }
+            },
+            'dap_service': {
+                "doi_naan": "10.88888",
+                "nerdstorage": {
+#                    "type": "fsbased",
+#                    "store_dir": os.path.join(tmpdir.name, "nrdstore")
+                    "type": "inmem",
+                },
+                "default_responsible_org": {
+                    "@type": "org:Organization",
+                    "@id": mds3.NIST_ROR,
+                    "title": "NIST"
+                },
+                "reviewer_ids": [ "npsop" ]
+            },
+            "authentication": {
+                "auth_key": "secret",
+                "user": "npsop",
+                "client": "nps",
+                "raise_on_anonymous": True
+            }
+        }
+        self.log = logging.getLogger()
+
+        if not os.path.exists(datadir):
+            os.mkdir(datadir)
+        
+        self.app = wsgi.ExternalReviewApp(self.cfg)
+        self.resp = []
+        self.rootpath = "/"
+
+    def tearDown(self):
+        if os.path.isdir(datadir):
+            shutil.rmtree(datadir)
+
+    def create_service(self):
+        user = Agent("unittest", Agent.AUTO, "test", Agent.PUBLIC)
+        return self.app.svcfact.create_service_for(user)
+
+    def create_record(self):
+        svc = self.create_service()
+        prec = svc.create_record("testrec")
+        svc._set_review_permissions(prec)
+        prec.save()
+        return prec.id
+
+    def test_handle(self):
+        path = ""
+        req = {
+            'REQUEST_METHOD': 'GET',
+            'PATH_INFO': self.rootpath + path,
+            'HTTP_AUTHORIZATION': "Bearer: secret"
+        }
+        who = Agent("unittest", Agent.AUTO, "npsop", Agent.PUBLIC)
+        body = self.app.handle_path_request("", req, self.start, who)
+
+        # nothings there yet
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(resp, [])
+
+        # try again after record creation
+        id = self.create_record()
+        body = self.app.handle_path_request("", req, self.start, who)
+
+        # nothing is open
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(resp, [])
+
+        # start a review
+        # self.create_service().apply_external_review(id, "nps", "requested", id)
+        self.resp = []
+        path = id
+        post = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path,
+            'HTTP_AUTHORIZATION': "Bearer: secret",
+            'wsgi.input': StringIO(json.dumps({"reviewReason": "initial"}))
+        }
+        body = self.app.handle_path_request(id, post, self.start, who)
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(resp['@id'], id)
+        self.assertEqual(resp['system'], "nps1")
+        self.assertEqual(resp['phase'], "in progress")
+        self.assertFalse(resp.get('feedback'))
+        
+        # recheck get
+        self.resp = []
+        body = self.app.handle_path_request("", req, self.start, who)
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(len(resp), 1)
+        self.assertEqual(resp[0]['@id'], id)
+        self.assertEqual(resp[0]['system'], "nps1")
+        self.assertEqual(resp[0]['phase'], "in progress")
+
+        # get the specific review
+        self.resp = []
+        path = id
+        req = {
+            'REQUEST_METHOD': 'GET',
+            'PATH_INFO': self.rootpath + path,
+            'HTTP_AUTHORIZATION': "Bearer: secret"
+        }
+        body = self.app.handle_path_request(id, req, self.start, who)
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(resp['@id'], id)
+        self.assertEqual(resp['system'], "nps1")
+
+        # request feedback
+        self.resp = []
+        post['wsgi.input'] = StringIO(json.dumps({"reviewResponse": False}))
+        body = self.app.handle_path_request(id, post, self.start, who)
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(resp['@id'], id)
+        self.assertEqual(resp['system'], "nps1")
+        self.assertEqual(resp['phase'], "paused")
+        self.assertEqual(len(resp['feedback']), 1)
+        fb = resp['feedback'][0]
+        self.assertEqual(fb['type'], "req")
+        self.assertTrue(fb['description'].startswith("Visit NPS"))
+
+        svc = self.create_service()
+        svc.submit(id)
+
+        # now approve
+        self.resp = []
+        post['wsgi.input'] = StringIO(json.dumps({"reviewResponse": True}))
+        body = self.app.handle_path_request(id, post, self.start, who)
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(resp['@id'], id)
+        self.assertEqual(resp['system'], "nps1")
+        self.assertEqual(resp['phase'], "approved")
+        self.assertEqual(resp['feedback'], [])
+
+        # recheck get
+        self.resp = []
+        body = self.app.handle_path_request(id, req, self.start, who)
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(resp['@id'], id)
+        self.assertEqual(resp['system'], "nps1")
+        self.assertEqual(resp['phase'], "approved")
+        self.assertEqual(resp['feedback'], [])
+
+        self.resp = []
+        body = self.app.handle_path_request("", req, self.start, who)
+        self.assertIn("200 ", self.resp[0])
+        resp=self.body2dict(body)
+        self.assertEqual(len(resp), 0)
+
+                         
+if __name__ == '__main__':
+    test.main()
+
+
+

--- a/python/tests/nistoar/midas/dap/extrev/test_wsgi.py
+++ b/python/tests/nistoar/midas/dap/extrev/test_wsgi.py
@@ -110,8 +110,8 @@ class TestLegacyNPSFeedbackHandler(test.TestCase):
     def create_record(self):
         svc = self.create_service()
         prec = svc.create_record("testrec")
-        svc._set_review_permissions(prec)
-        prec.save()
+#        svc._set_review_permissions(prec)
+#        prec.save()
         return prec.id
 
     def test_handle(self):
@@ -137,6 +137,10 @@ class TestLegacyNPSFeedbackHandler(test.TestCase):
         self.assertIn("200 ", self.resp[0])
         resp=self.body2dict(body)
         self.assertEqual(resp, [])
+
+        # submit for review so we can receive feedback
+        svc = self.create_service()
+        svc.submit(id)
 
         # start a review
         # self.create_service().apply_external_review(id, "nps", "requested", id)
@@ -193,9 +197,6 @@ class TestLegacyNPSFeedbackHandler(test.TestCase):
         fb = resp['feedback'][0]
         self.assertEqual(fb['type'], "req")
         self.assertTrue(fb['description'].startswith("Visit NPS"))
-
-        svc = self.create_service()
-        svc.submit(id)
 
         # now approve
         self.resp = []

--- a/python/tests/nistoar/midas/dap/extrev/testfb_uwsgi.py
+++ b/python/tests/nistoar/midas/dap/extrev/testfb_uwsgi.py
@@ -1,0 +1,129 @@
+"""
+This is a stand-alone feedback server specifically for responding to unit test requests
+"""
+import tempfile, sys, os, logging, signal
+import traceback as tb
+from wsgiref.simple_server import make_server, WSGIServer
+from socketserver import ThreadingMixIn
+
+from nistoar.midas.dap.extrev import wsgi
+from nistoar.midas.dap.service import mds3
+from nistoar.midas.dbio import AlreadyExists, PUBLIC_GROUP
+from nistoar.pdr.utils.prov import Agent
+
+try:
+    import uwsgi
+except ImportError:
+    print("Warning: running testfb_uwsgi in simulate mode", file=sys.stderr)
+    class uwsgi_mod(object):
+        def __init__(self):
+            self.opt={}
+    uwsgi=uwsgi_mod()
+
+LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
+tmpdir = None
+
+def make_config(workdir):
+    datadir = os.path.join(workdir, "dbfiles")
+    if not os.path.exists(datadir):
+        os.mkdir(datadir)
+    return {
+        'dbio': {
+            "factory": "fsbased",
+            "db_root_dir": datadir,
+            "project_id_minting": {
+                "default_shoulder": {
+                    "public": "mds3"
+                },
+                "localid_providers": {
+                    "public": [ "mds3" ]
+                }
+            }
+        },
+        'dap_service': {
+            "doi_naan": "10.88888",
+            "nerdstorage": {
+#                "type": "fsbased",
+#                "store_dir": os.path.join(tmpdir.name, "nrdstore")
+                "type": "inmem",
+            },
+            "default_responsible_org": {
+                "@type": "org:Organization",
+                "@id": mds3.NIST_ROR,
+                "title": "NIST"
+            },
+            "reviewer_ids": [ "npsop" ]
+        },
+        "authentication": {
+            "authorized": [
+                {
+                    "auth_key": "secret",
+                    "user": "npsop",
+                    "client": "nps",
+                }
+            ],
+            "raise_on_anonymous": True
+        }
+    }
+
+class FatalError(Exception):
+    def __init__(self, message, excode=1):
+        if not isinstance(excode, int):
+            excode = -1
+        super(FatalError, self).__init__(message)
+        self.exitcode = excode
+
+def clean_up(*args):
+    if tmpdir:
+        tmpdir.cleanup()
+        print("Working directory cleaned up", file=sys.stderr)
+
+def create_app(workdir):
+    return wsgi.app(make_config(workdir))
+
+def init_data(fbapp):
+    who = Agent("test", Agent.AUTO, "tester")
+    svc = fbapp.svcfact.create_service_for(who)
+    try:
+        prec = svc.create_record("testrec", {"title": "Test Record"}, dbid="mds3:0001")
+    except AlreadyExists as ex:
+        pass
+    else:
+        svc.apply_external_review(prec.id, "nps1", "requested", _prec=prec)
+        svc._set_review_permissions(prec, PUBLIC_GROUP)
+        prec.save()
+
+class TestWSGIServer(WSGIServer, ThreadingMixIn):
+    pass
+
+def setup(prog, *args):
+    workdir = None
+    if len(args) > 0 and args[0]:
+        workdir = os.path.abspath(args[0])
+        if not os.path.isdir(workdir):
+            if not os.path.isdir(os.path.dirname(workdir)):
+                raise FatalError(f"Work directory parent does not exist as a directory ({str(ex)})", 3)
+            try:
+                os.mkdir(workdir)
+            except OSError as ex:
+                raise FatalError("Failed to create work directory: " + str(ex)) from ex
+    else:
+        global tmpdir
+        tmpdir = tempfile.TemporaryDirectory(prefix=f"{prog}_")
+        workdir = tmpdir.name
+
+    logpath = os.path.join(workdir, "feedback_server.log")
+    logging.basicConfig(format=LOG_FORMAT, filename=logpath, level=logging.DEBUG)
+        
+    app = create_app(workdir)
+    init_data(app)
+    return app
+
+def _dec(obj):
+    # decode an object if it is not None
+    return obj.decode() if isinstance(obj, (bytes, bytearray)) else obj
+
+prog = os.path.splitext(os.path.basename(__file__))[0]
+workdir = _dec(uwsgi.opt.get("workdir"))
+application = setup(prog, workdir)
+

--- a/python/tests/nistoar/midas/dap/service/test_mds3_rev.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3_rev.py
@@ -127,7 +127,7 @@ class TestMDS3DAPServiceWithExtRev(test.TestCase):
         self.assertEqual(stat.state, status.SUBMITTED)
         self.assertIn(id, self.revcli.projs)
         self.assertEqual(self.revcli.projs[id]['phase'], "requested")
-        self.assertIsNone(stat.get_review_from("simulated"))
+        self.assertIsNotNone(stat.get_review_from("simulated"))  
 
         # progress the review
         self.revcli.update(id, "group")

--- a/python/tests/nistoar/midas/dap/service/test_mds3_rev.py
+++ b/python/tests/nistoar/midas/dap/service/test_mds3_rev.py
@@ -104,7 +104,7 @@ class TestMDS3DAPServiceWithExtRev(test.TestCase):
         self.assertIs(self.revcli, self.svc._extrevcli)
         self.assertEqual(self.revcli.system_name, "simulated")
         self.assertIs(self.revcli.projsvc, self.svc)
-        self.assertTrue(self.revcli.autoapp)
+        self.assertFalse(self.revcli.autoapp)
 
     def test_submit(self):
         self.create_service()
@@ -127,7 +127,7 @@ class TestMDS3DAPServiceWithExtRev(test.TestCase):
         self.assertEqual(stat.state, status.SUBMITTED)
         self.assertIn(id, self.revcli.projs)
         self.assertEqual(self.revcli.projs[id]['phase'], "requested")
-        self.assertIsNone(stat.get_review_from("sim"))
+        self.assertIsNone(stat.get_review_from("simulated"))
 
         # progress the review
         self.revcli.update(id, "group")
@@ -214,7 +214,8 @@ class TestMDS3DAPServiceWithExtRev(test.TestCase):
         self.assertIn(id, self.revcli.projs)
         self.assertEqual(self.revcli.projs[id]['phase'], "approved")
         self.assertIsNone(stat.get_review_from("sim"))
-        self.assertEqual(stat.state, status.PUBLISHED)
+#        self.assertIsNotNone(stat.get_review_from("simulated"))
+        self.assertEqual(stat.state, status.ACCEPTED)
 
         
     def test_submit_revise(self):

--- a/python/tests/nistoar/midas/dbio/test_status.py
+++ b/python/tests/nistoar/midas/dbio/test_status.py
@@ -174,6 +174,7 @@ class TestRecordStatus(test.TestCase):
         self.assertEqual(rdata["@id"], "goob")
         self.assertEqual(rdata["info_at"], "/od/id/goob")
         self.assertEqual(rdata["phase"], "group-review")
+        self.assertTrue(rdata["updated"] > 0)
         self.assertNotIn("feedback", rdata)
 
         fb = {

--- a/python/tests/nistoar/midas/dbio/test_status.py
+++ b/python/tests/nistoar/midas/dbio/test_status.py
@@ -165,6 +165,7 @@ class TestRecordStatus(test.TestCase):
         stat = status.RecordStatus("goob", {})
         sdata = stat.to_dict()
         self.assertNotIn("external_review", sdata)
+        self.assertEqual(stat.get_review_systems(), [])
 
         stat.pubreview("nps", "group-review", "goob", "/od/id/goob")
         sdata = stat.to_dict()
@@ -196,6 +197,10 @@ class TestRecordStatus(test.TestCase):
         self.assertEqual(rdata["feedback"][0]["reviewer"], "jerry")
         self.assertEqual(rdata["feedback"][0]["type"], "warn")
         self.assertTrue(rdata["feedback"][0]["description"])
+
+        self.assertEqual(stat.get_review_systems(), ['nps'])
+        rdata['system'] = 'nps'
+        self.assertEqual(stat.get_review_from('nps'), rdata)
 
         fb = {
             "reviewer": "gary",
@@ -269,6 +274,15 @@ class TestRecordStatus(test.TestCase):
         self.assertEqual(rdata["phase"], "tech")
         self.assertNotIn("gurn", rdata)
         self.assertNotIn("feedback", rdata)
+
+        syss = stat.get_review_systems()
+        self.assertIn('nps', syss)
+        self.assertIn('elrs', syss)
+        self.assertEqual(len(syss), 2)
+        stat.delete_review_from("elrs")
+        self.assertIsNone(stat.get_review_from("elrs"))
+        stat.pubreview("elrs", "snoop")
+        self.assertIsNotNone(stat.get_review_from("elrs"))
 
         stat.publish("gurn", "1.2.0")
         sdata = stat.to_dict()

--- a/scripts/npsfeedback-uwsgi.py
+++ b/scripts/npsfeedback-uwsgi.py
@@ -1,0 +1,180 @@
+"""
+the uWSGI script for launching the NPS feedback service
+
+This script launches the web service using uwsgi.  For example, one can 
+launch the service with the following command:
+
+  uwsgi --plugin python3 --http-socket :9090 --wsgi-file midas-uwsgi.py     \
+        --set-ph oar_config_file=midas_conf.yml --set-ph oar_working_dir=_test
+
+The configuration data can be provided to this script via a file (as illustrated above) or it 
+can be fetched from a configuration service, depending on the environment (see below).  See the 
+documentation for nistoar.midas.dap.extrev.wsgi for the configuration parameters supported by this 
+service.
+
+This script also pays attention to the following environment variables:
+
+   OAR_HOME            The directory where the OAR PDR system is installed; this 
+                          is used to find the OAR PDR python package, nistoar.
+   OAR_PYTHONPATH      The directory containing the PDR python module, nistoar.
+                          This overrides what is implied by OAR_HOME.
+   OAR_CONFIG_SERVICE  The base URL for the configuration service; this is 
+                          overridden by the oar_config_service uwsgi variable. 
+   OAR_CONFIG_ENV      The application/component name for the configuration; 
+                          this is only used if OAR_CONFIG_SERVICE is used.
+   OAR_CONFIG_TIMEOUT  The max number of seconds to wait for the configuration 
+                          service to come up (default: 10);
+                          this is only used if OAR_CONFIG_SERVICE is used.
+   OAR_CONFIG_APP      The name of the component/application to retrieve 
+                          configuration data for (default: midas-npsfb);
+                          this is only used if OAR_CONFIG_SERVICE is used.
+"""
+import os, sys, logging, copy
+from copy import deepcopy
+
+try:
+    import nistoar
+except ImportError:
+    oarpath = os.environ.get('OAR_PYTHONPATH')
+    if not oarpath and 'OAR_HOME' in os.environ:
+        oarpath = os.path.join(os.environ['OAR_HOME'], "lib", "python")
+    if oarpath:
+        sys.path.insert(0, oarpath)
+    import nistoar
+
+import nistoar.midas
+from nistoar.base import config
+from nistoar.midas.dbio import MongoDBClientFactory, InMemoryDBClientFactory, FSBasedDBClientFactory
+from nistoar.midas.dap.extrev import wsgi
+
+try:
+    import uwsgi
+except ImportError:
+    # simulate uwsgi for testing purpose
+    from nistoar.testing import uwsgi
+    uwsgi = uwsgi.load()
+
+def _dec(obj):
+    # byte-decode an object if it is not None
+    return obj.decode() if isinstance(obj, (bytes, bytearray)) else obj
+
+DEF_MIDAS_DB_TYPE="fsbased"
+
+# determine where the configuration is coming from
+confsvc = None
+confsrc = _dec(uwsgi.opt.get("oar_config_file"))
+confto = 10
+cfg = None
+if confsrc:
+    cfg = config.resolve_configuration(confsrc)
+
+elif 'oar_config_service' in uwsgi.opt:
+    confsvc = config.ConfigService(_dec(uwsgi.opt.get('oar_config_service')),
+                                   _dec(uwsgi.opt.get('oar_config_env')))
+    confto = int(_dec(uwsgi.opt.get('oar_config_timeout', 10)))
+
+elif config.service:
+    confsvc = config.service
+    confto = int(os.environ.get('OAR_CONFIG_TIMEOUT', 10))
+
+if cfg is None:
+    if confsvc:
+        confsvc.wait_until_up(confto, True, sys.stderr)
+        cfg = confsvc.get(_dec(uwsgi.opt.get('oar_config_appname', 
+                                         os.environ.get('OAR_CONFIG_APP', 'midas-npsfb'))))
+    else:
+        raise config.ConfigurationException("npsfeedback: nist-oar configuration not provided")
+
+if isinstance(cfg.get("dbio"), str) or isinstance(cfg.get("dap_service"), str):
+    # String values here (instead of dictionaries) mean pull the configuration from this name and
+    # merge in the parameters found there.  The value is typically "midas-dbio"; this allows us to
+    # ensure that the DAP service we use here has the same essential configuration as the DBIO service
+    # (which, in production, is running at the same time).  
+    altcfg = None
+    if uwsgi.opt.get('oar_midas_config_file'):
+        altcfg = config.resolve_configuration(_dec(uwsgi.opt.get('oar_midas_config_file')))
+    elif not confsvc:
+        raise config.ConfigurationException("dbio/dap_service: unable to fetch reference config data: "
+                                            "no config service available")
+
+    if isinstance(cfg.get("dbio"), str):
+        if not altcfg:
+            altcfg = confsvc.get(cfg['dbio'])
+        cfg['dbio'] = altcfg.get('dbio', {})
+    if isinstance(cfg.get("dap_service"), str):
+        if confsvc and (altcfg is None or cfg.get("dap_service") != cfg.get("dbio")):
+            altcfg = confsvc.get(cfg['dap_service'])
+        if altcfg.get('dap_service'):
+            cfg['dap_service'] = altcfg['dap_service']
+        elif altcfg.get('services'):
+            # altcfg is using the midas-dbio schema
+            dapcfg = altcfg['services'].get('dap', {})
+            conv = dapcfg.get('default_convention', 'mds3')
+            cfg['dap_service'] = dapcfg.get('conventions', {}).get(conv, {})
+            cfg['dap_service']['dbio'] = config.merge_config(cfg['dap_service'].get('dbio', {}),  #primary
+                                                             dapcfg.get('dbio', {}))              #default
+        else:
+            raise config.ConfigurationException("dap_service: Unable to find dap configuration in "+
+                                                cfg['dap_service'])
+
+workdir = _dec(uwsgi.opt.get("oar_working_dir"))
+if workdir:
+    cfg['working_dir'] = workdir
+
+config.configure_log(config=cfg)
+
+# setup the MIDAS database backend
+dbtype = _dec(uwsgi.opt.get("oar_midas_db_type"))
+if not dbtype:
+    dbtype = cfg.get("dbio", {}).get("factory")
+if not dbtype:
+    dbtype = DEF_MIDAS_DB_TYPE
+
+dbcfg = cfg.get("dbio", {})
+if dbtype == "mongo":
+    # ensure the DB URL
+    if os.environ.get("OAR_MONGODB_URL"):
+        dbcfg['db_url'] = os.environ['OAR_MONGODB_URL']
+    if not dbcfg.get('db_url'):
+        # Build the DB URL from its pieces with env vars taking precedence over the config
+        port = ":%s" % os.environ.get("OAR_MONGODB_PORT", dbcfg.get("port", "27017"))
+        user = os.environ.get("OAR_MONGODB_USER", dbcfg.get("user"))
+        cred = ""
+        if user:
+            pasw = os.environ.get("OAR_MONGODB_PASS", dbcfg.get("pw", os.environ.get("OAR_MONGODB_USER")))
+            cred = "%s:%s@" % (user, pasw)
+        host = os.environ.get("OAR_MONGODB_HOST", dbcfg.get("host", "localhost"))
+        dbcfg['db_url'] = "mongodb://%s%s%s/midas" % (cred, host, port)
+
+elif dbtype == "fsbased":
+    # determine the DB's root directory
+    wdir = cfg.get('working_dir','.')
+    if not dbcfg.get('db_root_dir'):
+        # use a default under the working directory
+        dbcfg['db_root_dir'] = os.path.join(wdir, "dbfiles")
+        if not os.path.exists(wdir):
+            os.mkdir(wdir)
+    elif not os.path.isabs(dbcfg['db_root_dir']):
+        # if relative, make it relative to the work directory
+        dbcfg['db_root_dir'] = os.path.join(wdir, dbcfg['db_root_dir'])
+        if not os.path.exists(wdir):
+            os.mkdir(wdir)
+        if not os.path.exists(dbcfg['db_root_dir']):
+            os.makedirs(dbcfg['db_root_dir'])
+    if not os.path.exists(dbcfg['db_root_dir']):
+        os.mkdir(dbcfg['db_root_dir'])
+
+elif dbtype == "inmem":
+    nscfg = cfg.get("dap_service", {}).get("nerdstorage",{})
+    if nscfg:
+        nscfg['type'] = "inmem"
+
+else:
+    raise RuntimeError("Unsupported database type: "+dbtype)
+
+# uwsgi uses the "application" symbol as the WSGI application object
+application = wsgi.app(cfg)
+
+msg = f"NPS Feedback service (v{nistoar.midas.__version__}) ready with {dbtype} backend"
+print(msg)
+logging.info(msg)


### PR DESCRIPTION
This PR provides a general framework DBIO record review and adds an implementation that integrates with the NIST Publication System (NPS).

The framework is based around the following design features:
  *  a DBIO `ProjectService` can be configured to interact with zero or more external review systems.
  *  if so configured, when a user submits a record for publication, the service registers the record with the configured review system through a common API.  (One implementation talks to NPS.)
  *  the external review system can send feedback to the service multiple times as the review evolves
  *  often feedback is simply about reporting on progress through the review process, but the review system can also report desired changes reviewers would like to see made to the record.  This can trigger the record to be returned to edit mode to allow the authors to make those changes.  Afterward, the authors resubmit the record to continue the review process.
  *  feedback information from all active external review systems are saved into the DBIO record's `status` property, making it available for display in front-end tools (e.g. the DAPTool)
  *  the final report of feedback is to approve publication and close out the interaction with that review system.  This can then trigger final publication.

The PR includes an implementation of the framework that connects NPS to the `DAPService`.  This initial implementation is compatible with the current NPS API.  The current NPS is not capable of taking full advantage of the DBIO's feedback API; the `DAPService` compensates by occasionally pulling what information it can to communicate status back to the user.  