### PR TITLE
Feature/groups list acl widget

### DIFF
--- a/docker/midasserver/midas-dmpdapnsd_conf.yml
+++ b/docker/midasserver/midas-dmpdapnsd_conf.yml
@@ -120,8 +120,13 @@ services:
        describedBy: "http://localhost:9091/docs/groupsvc-elements.html"
      dbio:
        superusers: [ "rlp3" ]
-       allowed_group_shoulders: [ "grp0" ]
-       default_shoulder: grp0
+       group_id_minting:
+         default_shoulder:
+           nist: grp0
+           public: grp0
+         allowed_shoulders:
+           nist: [ "grp0" ]
+           public: [ "grp0" ]
      default_convention: grp0
      conventions:
        grp0: {}

--- a/docs/groupsvc-openapi.yml
+++ b/docs/groupsvc-openapi.yml
@@ -20,6 +20,21 @@ paths:
     summary: the collection of all groups for this version shoulder (e.g. grp0)
     parameters:
       - $ref: "#/components/parameters/version"
+    get:
+      summary: list all groups the caller owns or belongs to
+      responses:
+        "200":
+          description: list of groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GroupRecord"
+        "401":
+          description: unauthenticated
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/ErrorResponse" } }
     post:
       summary: create a new group
       requestBody:

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -819,6 +819,19 @@ class DBGroups(object):
 
         return out
 
+    def select_for_user(self, user_id: str) -> Iterator[Group]:
+        """
+        return all groups the user owns or is a direct member of.
+        """
+        seen = set()
+        for rec in self._cli._select_from_coll(GROUPS_COLL, owner=user_id):
+            seen.add(rec['id'])
+            yield Group(rec, self._cli)
+        for rec in self._cli._select_prop_contains(GROUPS_COLL, 'members', user_id):
+            if rec['id'] not in seen:
+                seen.add(rec['id'])
+                yield Group(rec, self._cli)
+
     def delete_group(self, gid: str) -> bool:
         """
         delete the specified group from the database.  The user attached to the underlying

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1070,12 +1070,12 @@ class DBClient(ABC):
         if not person:
             return []
         out = []
-        if 'ouOrgID' in person and person['ouOrgID']:
-            out.append(f"nistou:{person['ouOrgID']}")
-        if 'divisionOrgID' in person and person['divisionOrgID']:
-            out.append(f"nistdiv:{person['divisionOrgID']}")
-        if 'groupOrgID' in person and person['groupOrgID']:
-            out.append(f"nistgrp:{person['groupOrgID']}")
+        if 'nistou' in person and person['nistou']:
+            out.append(f"nistou:{person['nistou']}")
+        if 'nistdiv' in person and person['nistdiv']:
+            out.append(f"nistdiv:{person['nistdiv']}")
+        if 'nistgrp' in person and person['nistgrp']:
+            out.append(f"nistgrp:{person['nistgrp']}")
         return out
 
     def create_record(self, name: str, shoulder: str = None,

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1070,12 +1070,15 @@ class DBClient(ABC):
         if not person:
             return []
         out = []
-        if 'nistou' in person and person['nistou']:
-            out.append(f"nistou:{person['nistou']}")
-        if 'nistdiv' in person and person['nistdiv']:
-            out.append(f"nistdiv:{person['nistdiv']}")
-        if 'nistgrp' in person and person['nistgrp']:
-            out.append(f"nistgrp:{person['nistgrp']}")
+        ou_number = person.get('ouNumber')
+        if ou_number:
+            out.append(f"nistou:{ou_number}")
+        division_number = person.get('divisionNumber')
+        if division_number:
+            out.append(f"nistdiv:{division_number}")
+        group_number = person.get('groupNumber')
+        if group_number:
+            out.append(f"nistgrp:{group_number}")
         return out
 
     def create_record(self, name: str, shoulder: str = None,

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -733,11 +733,13 @@ class DBGroups(object):
         :param str shoulder:   the shoulder to prefix to the identifier.  The value usually controls
                                how the identifier is formed.
         """
-        # determine shoulder if not provided
         mintcfg = self._cli._cfg.get("group_id_minting", {})
         if not shoulder:
-            shoulder = self._cli._get_default_shoulder(mintcfg, self._cli._who)    # may raise NotAuthorized
-        elif not self._cli._authorized_for_shoulder(mintcfg, shoulder, self._cli._who):
+            if mintcfg:
+                shoulder = self._cli._get_default_shoulder(mintcfg, self._cli._who)
+            else:
+                shoulder = DEF_GROUPS_SHOULDER
+        elif mintcfg and not self._cli._authorized_for_shoulder(mintcfg, shoulder, self._cli._who):
             raise NotAuthorized(str(self._cli._who), f"create a group under the {shoulder}")
 
         return "{}:{}:{}".format(shoulder, owner, name)

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1070,12 +1070,12 @@ class DBClient(ABC):
         if not person:
             return []
         out = []
-        if 'nistou' in person and person['nistou']:
-            out.append(f"nistou:{person['nistou']}")
-        if 'nistdiv' in person and person['nistdiv']:
-            out.append(f"nistdiv:{person['nistdiv']}")
-        if 'nistgrp' in person and person['nistgrp']:
-            out.append(f"nistgrp:{person['nistgrp']}")
+        if 'ouOrgID' in person and person['ouOrgID']:
+            out.append(f"nistou:{person['ouOrgID']}")
+        if 'divisionOrgID' in person and person['divisionOrgID']:
+            out.append(f"nistdiv:{person['divisionOrgID']}")
+        if 'groupOrgID' in person and person['groupOrgID']:
+            out.append(f"nistgrp:{person['groupOrgID']}")
         return out
 
     def create_record(self, name: str, shoulder: str = None,

--- a/python/nistoar/midas/dbio/wsgi/group.py
+++ b/python/nistoar/midas/dbio/wsgi/group.py
@@ -125,6 +125,11 @@ class GroupService:
         grp.save()
         return True
 
+    def list_groups(self) -> list:
+        """Return all groups the current user owns or belongs to."""
+        user_id = self._cli.user_id
+        return [g.to_dict() for g in self._groups.select_for_user(user_id)]
+
 
 class GroupServiceFactory:
     """
@@ -158,7 +163,17 @@ class GroupSelectionHandler(DBIOHandler):
         self._shoulder = shoulder
 
     def do_OPTIONS(self, path):
-        return self.send_options(["POST"])
+        return self.send_options(["GET", "POST"])
+
+    def do_GET(self, path, ashead=False):
+        """
+        GET /{shoulder} — list all groups the caller owns or belongs to.
+        """
+        try:
+            groups = self.svc.list_groups()
+            return self.send_json(groups, ashead=ashead)
+        except NotAuthorized:
+            return self.send_unauthorized()
 
     def do_POST(self, path):
         """

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -1092,7 +1092,7 @@ class ProjectACLsHandler(ProjectRecordHandler):
             # remove the identity from the ACL
             try:
                 prec.acls.revoke_perm_from(parts[0], parts[1])
-                prec.save()
+                prec.save(dbio.ACLs.ADMIN)
                 return self.send_ok(message="ID removed")
             except dbio.NotAuthorized as ex:
                 return self.send_unauthorized()

--- a/python/tests/nistoar/midas/dbio/test_group.py
+++ b/python/tests/nistoar/midas/dbio/test_group.py
@@ -84,18 +84,18 @@ class TestMIDASGroupApp(test.TestCase):
 
     def test_no_shoulder_provided(self):
         """
-        If we call /midas/group/ with no <shoulder>, we expect a 500 or 400
-        because group.py expects a shoulder.
+        GET /midas/group/ with no shoulder uses the default shoulder and returns 200.
         """
         path = ""
         req = {
             'REQUEST_METHOD': 'GET',
             'PATH_INFO': self.rootpath + path
         }
-        # This should fail because group.py checks for a shoulder
         hdlr = self.app.create_handler(req, self.start, path, test_agent)
         body = hdlr.handle()
-        self.assertIn("405 ", self.resp[0])
+        self.assertIn("200 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertIsInstance(resp, list)
 
     def test_create_group(self):
         """
@@ -119,6 +119,37 @@ class TestMIDASGroupApp(test.TestCase):
         # The ID can be "grp0:tester1:my-test-group" or similar
         self.assertIn("grp0:tester1:", resp['id'])
         self.assertEqual(resp['members'], ["tester1"])  # By default, the group is owned by user
+
+    def test_list_groups(self):
+        """
+        GET /midas/group/grp0 returns all groups the caller owns or belongs to.
+        """
+        path = "grp0"
+
+        # create two groups as test_agent (tester1)
+        for name in ["alpha", "beta"]:
+            req = {
+                'REQUEST_METHOD': 'POST',
+                'PATH_INFO': self.rootpath + path,
+                'wsgi.input': StringIO(json.dumps({"name": name}))
+            }
+            self.app.create_handler(req, self.start, path, test_agent).handle()
+            self.resp = []
+
+        # list groups
+        req = {
+            'REQUEST_METHOD': 'GET',
+            'PATH_INFO': self.rootpath + path
+        }
+        hdlr = self.app.create_handler(req, self.start, path, test_agent)
+        body = hdlr.handle()
+
+        self.assertIn("200 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertIsInstance(resp, list)
+        self.assertEqual(len(resp), 2)
+        names = {g['name'] for g in resp}
+        self.assertEqual(names, {"alpha", "beta"})
 
     def test_create_group_missing_name(self):
         """

--- a/python/tests/nistoar/midas/dbio/test_groups.py
+++ b/python/tests/nistoar/midas/dbio/test_groups.py
@@ -413,8 +413,8 @@ class TestVirtualGroups(test.TestCase):
 
     def test_all_groups_for_withMockPeopleService(self):
         staffdata = {
-            "nist0:ava1": { "nistou": "728", "nistdiv": "730" },
-            "nist0:alice": { "nistgrp": "999" }
+            "nist0:ava1": { "ouNumber": "728", "divisionNumber": "730" },
+            "nist0:alice": { "groupNumber": "999" }
         }
         pplsvc = MockPeopleService(staffdata)
         newcli = self.fact.create_client(base.DMP_PROJECTS, self.clientcfg, self.user)
@@ -437,8 +437,8 @@ class TestVirtualGroups(test.TestCase):
 
     def test_recache_user_groups_withMockPeopleService(self):
         staffdata = {
-            "nist0:ava1": { "nistou": "728", "nistdiv": "730" },
-            "nist0:alice": { "nistgrp": "999" }
+            "nist0:ava1": { "ouNumber": "728", "divisionNumber": "730" },
+            "nist0:alice": { "groupNumber": "999" }
         }
         pplsvc = MockPeopleService(staffdata)
         newcli = self.fact.create_client(base.DMP_PROJECTS, self.clientcfg, self.user)
@@ -469,11 +469,11 @@ class TestVirtualGroups(test.TestCase):
 
     def test_authorized_via_virtual_group(self):
         # Grant read access to a virtual group ID (nistou:728).
-        # A user whose NSD entry maps to nistou:728 should pass authorized(),
+        # A user whose NSD entry maps to ouNumber 728 should pass authorized(),
         # while a user in a different OU and a user absent from NSD should not.
         staffdata = {
-            "nist0:ava1": {"nistou": "728", "nistdiv": "730"},
-            "nist0:bob":  {"nistgrp": "999"},
+            "nist0:ava1": {"ouNumber": "728", "divisionNumber": "730"},
+            "nist0:bob":  {"groupNumber": "999"},
         }
         pplsvc = MockPeopleService(staffdata)
         cli = self.fact.create_client(base.DMP_PROJECTS, self.clientcfg, "alice")

--- a/python/tests/nistoar/midas/dbio/test_groups.py
+++ b/python/tests/nistoar/midas/dbio/test_groups.py
@@ -311,6 +311,29 @@ class TestDBGroups(test.TestCase):
         self.assertIn(base.PUBLIC_GROUP, matches)
         self.assertEqual(len(matches), 4)
 
+    def test_select_for_user(self):
+        # two groups owned by self.user
+        g1 = self.dbg.create_group("team-a")
+        g2 = self.dbg.create_group("team-b")
+
+        # one group created by another user, with self.user added as member
+        other_cli = self.fact.create_client(base.DMP_PROJECTS, self.cfg, "other-user")
+        g3 = other_cli.groups.create_group("other-team")
+        g3.add_member(self.user)
+        g3.save()
+
+        results = list(self.dbg.select_for_user(self.user))
+        ids = [g.id for g in results]
+        self.assertIn(g1.id, ids)
+        self.assertIn(g2.id, ids)
+        self.assertIn(g3.id, ids)   # member but not owner
+        self.assertEqual(len(ids), 3)  # no duplicates
+
+        # user with no groups sees nothing
+        stranger_cli = self.fact.create_client(base.DMP_PROJECTS, self.cfg, "stranger")
+        results = list(stranger_cli.groups.select_for_user("stranger"))
+        self.assertEqual(len(results), 0)
+
 
 class MockPeopleService(base.PeopleService):
     def __init__(self, staffdata):


### PR DESCRIPTION
This branch adds the backend support for the Share My Records permission
manager: group CRUD endpoints, ACL read/write endpoints per record, and
the logic that resolves which groups a user belongs to when evaluating access.

The most important fix is in _get_virtual_groups_for() in base.py. This
function derives a user's NIST org memberships from their People record so
that org-unit ACL subjects (like nistdiv:13289) work correctly. It was
reading ouOrgID, divisionOrgID, groupOrgID — fields that don't exist in
the MongoDB collection. The real field names are ouNumber, divisionNumber,
groupNumber. Without this fix, org-based sharing silently did nothing; with
it, users automatically inherit access granted to their division or group.