### PR TITLE
Fix advanced-search filter handling and query validation

### DIFF
--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1262,7 +1262,7 @@ class DBClient(ABC):
 
     @classmethod
     def check_query_structure(cls, query):
-        if not isinstance(query, dict):
+        if not isinstance(query, dict) or not query:
             return False
 
         valid_operators = ['$and', '$or', '$not', '$nor', '$eq', '$ne', '$gt', '$gte', '$lt',
@@ -1274,10 +1274,10 @@ class DBClient(ABC):
                 return False
 
             if isinstance(query[key], dict):
-                if not check_query_structure(query[key]):
+                if not cls.check_query_structure(query[key]):
                     return False
 
-            return True
+        return True
 
     @abstractmethod
     def select_records(self, perm: Permissions = ACLs.OWN, **constraints) -> Iterator[ProjectRecord]:

--- a/python/nistoar/midas/dbio/mongo.py
+++ b/python/nistoar/midas/dbio/mongo.py
@@ -272,7 +272,7 @@ class MongoDBClient(base.DBClient):
             else:
                 constraints = {"acls."+perm.pop(): {"$in": idents}}
                 
-            filter["$and"].append(constraints)
+            filter.setdefault("$and", []).append(constraints)
             try:
                 coll = self.native[self._projcoll]
                 for rec in coll.find(filter, {'_id': False}):

--- a/python/tests/nistoar/midas/dbio/test_client.py
+++ b/python/tests/nistoar/midas/dbio/test_client.py
@@ -185,6 +185,26 @@ class TestDBClient(test.TestCase):
         self.assertEqual(rec.name, "goob")
         self.assertEqual(rec.id, "pdr0:0003")
 
+    def test_check_query_structure(self):
+        check = base.DBClient.check_query_structure
+
+        self.assertTrue(check({"$and": [{"name": "test1"}]}))
+        self.assertTrue(check({"$or": [{"name": "test1"}, {"name": "test2"}]}))
+
+        # every key gets checked, not just the first one
+        self.assertFalse(check({"$or": [], "evil": 1}))
+        self.assertFalse(check({"$and": [], "$or": [], "drop": "me"}))
+
+        # nested operators recurse instead of raising NameError
+        self.assertTrue(check({"$not": {"$eq": 1}}))
+        self.assertTrue(check({"$not": {"$not": {"$gt": 3}}}))
+        self.assertFalse(check({"$not": {"evil": 1}}))
+
+        self.assertFalse(check({"bogus": 1}))
+        self.assertFalse(check({}))
+        self.assertFalse(check([]))
+        self.assertFalse(check("not a dict"))
+
     def test_select_records(self):
         rec = self.cli.create_record("mine1")
         rec = self.cli.create_record("mine2")

--- a/python/tests/nistoar/midas/dbio/test_mongo.py
+++ b/python/tests/nistoar/midas/dbio/test_mongo.py
@@ -589,7 +589,17 @@ class TestMongoDBClient(test.TestCase):
         self.assertEqual(recs[0].id, "pdr0:0002")
         self.assertEqual(recs[1].id, "pdr0:0006")
 
-        
+        # a filter that does not already carry a top-level $and still works
+        filter = {"$or": [{"name": "test 2"}, {"name": "test3"}]}
+        recs = list(self.cli.adv_select_records(filter, base.ACLs.READ))
+        self.assertEqual(len(recs), 2)
+        self.assertEqual(recs[0].id, "pdr0:0006")
+        self.assertEqual(recs[1].id, "pdr0:0003")
+
+        # the permission constraint is still applied to such a filter
+        self.assertEqual(len(filter["$and"]), 1)
+        idents = [self.cli.user_id] + list(self.cli.user_groups)
+        self.assertEqual(filter["$and"][0], {"acls.read": {"$in": idents}})
 
     def test_action_log_io(self):
         self.assertEqual(self.cli.native['prov_action_log'].count_documents({}), 0)


### PR DESCRIPTION
Reading through the DBIO advanced-search path (`POST <project>/:selected`) I ran into three bugs that all sit on the same call chain. Two of them turn input that looks perfectly reasonable into a 500. None of them are security issues, see the note near the bottom.

### 1. `filter["$and"]` assumes the key is already there

`mongo.py` attaches the permission constraint with:

```python
filter["$and"].append(constraints)
```

If the filter has no top-level `$and`, that is a `KeyError`. So the most obvious advanced query:

```json
{"filter": {"$or": [{"name": "test 2"}, {"name": "test3"}]}}
```

fails. `do_POST` only catches `SyntaxError`, `ValueError` and `AttributeError`, so the `KeyError` escapes as a 500 rather than a 400.

I think the reason this went unnoticed is that every fixture in `tests/nistoar/midas/dbio/data/asc*.json` already wraps its query in a top-level `$and`, so the append always finds the key. Switching to `setdefault` leaves that pre-wrapped case behaving exactly as before and just creates the list when it is missing.

### 2. `check_query_structure` only checks the first key

The `return True` is inside the loop:

```python
for key in query.keys():
    if key not in valid_operators:
        return False

    if isinstance(query[key], dict):
        if not check_query_structure(query[key]):
            return False

    return True
```

so validation stops after one key. `{"$or": [], "evil": 1}` is accepted and `evil` is never compared against `valid_operators`. Moved the return out of the loop so every key gets looked at.

### 3. The recursive call is unqualified inside a classmethod

The recursion calls `check_query_structure(...)` as a bare name from inside a `@classmethod`, so it raises `NameError` the moment that branch is taken, which is any nested-dict operator such as `{"$not": {"$eq": 1}}`. That is another uncaught 500. Changed it to `cls.check_query_structure(...)`. This one affects both backends, since inmem and mongo both call into the same method.

One related change: I added `or not query` to the type guard so an empty filter is still rejected. `check_query_structure({})` previously fell off the end and returned `None`, and `test_project.py` depends on that to get a 400 when a request arrives with no `filter` key. Without the guard, moving the return would have quietly turned an empty filter into a match-everything query.

### Not a security issue

Being explicit about scope since it touches a validation function: this is not an authz bypass. Both backends still AND the per-user permission constraint onto whatever the caller sent (`acls.<perm>: {"$in": [user_id] + groups}`), so a crafted filter cannot reach records the caller has no permission on. I added an assertion to the mongo test that the constraint is still appended for the filter shape that used to crash. The impact here is a broken feature and an easy authenticated 500, not data exposure.

### Testing

Ran the dbio suite against a throwaway Mongo 6 container with `MONGO_TESTDB_URL` set, so the mongo tests actually execute instead of skipping.

- before the fix: 212 passed, 6 skipped
- after the fix: 213 passed, 6 skipped

To confirm the new tests actually catch these, I reverted each fix on its own and re-ran:

- restoring `filter["$and"].append(...)` fails `test_mongo.py::TestMongoDBClient::test_adv_select_records`
- putting `return True` back inside the loop fails `test_client.py::TestDBClient::test_check_query_structure`
- changing `cls.check_query_structure` back to the bare name fails the same test

New coverage is `test_check_query_structure` in `test_client.py` (no mongo needed) plus an extra case in the existing mongo `test_adv_select_records` using a filter with no top-level `$and`.
