### PR TITLE
Feature/dmp csv export fields

### DIFF
--- a/docker/midasserver/midas-dmpdapnsd_conf.yml
+++ b/docker/midasserver/midas-dmpdapnsd_conf.yml
@@ -120,8 +120,13 @@ services:
        describedBy: "http://localhost:9091/docs/groupsvc-elements.html"
      dbio:
        superusers: [ "rlp3" ]
-       allowed_group_shoulders: [ "grp0" ]
-       default_shoulder: grp0
+       group_id_minting:
+         default_shoulder:
+           nist: grp0
+           public: grp0
+         allowed_shoulders:
+           nist: [ "grp0" ]
+           public: [ "grp0" ]
      default_convention: grp0
      conventions:
        grp0: {}

--- a/docs/groupsvc-openapi.yml
+++ b/docs/groupsvc-openapi.yml
@@ -20,6 +20,21 @@ paths:
     summary: the collection of all groups for this version shoulder (e.g. grp0)
     parameters:
       - $ref: "#/components/parameters/version"
+    get:
+      summary: list all groups the caller owns or belongs to
+      responses:
+        "200":
+          description: list of groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GroupRecord"
+        "401":
+          description: unauthenticated
+          content:
+            application/json: { schema: { $ref: "#/components/schemas/ErrorResponse" } }
     post:
       summary: create a new group
       requestBody:

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -819,6 +819,19 @@ class DBGroups(object):
 
         return out
 
+    def select_for_user(self, user_id: str) -> Iterator[Group]:
+        """
+        return all groups the user owns or is a direct member of.
+        """
+        seen = set()
+        for rec in self._cli._select_from_coll(GROUPS_COLL, owner=user_id):
+            seen.add(rec['id'])
+            yield Group(rec, self._cli)
+        for rec in self._cli._select_prop_contains(GROUPS_COLL, 'members', user_id):
+            if rec['id'] not in seen:
+                seen.add(rec['id'])
+                yield Group(rec, self._cli)
+
     def delete_group(self, gid: str) -> bool:
         """
         delete the specified group from the database.  The user attached to the underlying

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1070,12 +1070,12 @@ class DBClient(ABC):
         if not person:
             return []
         out = []
-        if 'ouOrgID' in person and person['ouOrgID']:
-            out.append(f"nistou:{person['ouOrgID']}")
-        if 'divisionOrgID' in person and person['divisionOrgID']:
-            out.append(f"nistdiv:{person['divisionOrgID']}")
-        if 'groupOrgID' in person and person['groupOrgID']:
-            out.append(f"nistgrp:{person['groupOrgID']}")
+        if 'nistou' in person and person['nistou']:
+            out.append(f"nistou:{person['nistou']}")
+        if 'nistdiv' in person and person['nistdiv']:
+            out.append(f"nistdiv:{person['nistdiv']}")
+        if 'nistgrp' in person and person['nistgrp']:
+            out.append(f"nistgrp:{person['nistgrp']}")
         return out
 
     def create_record(self, name: str, shoulder: str = None,

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1070,12 +1070,15 @@ class DBClient(ABC):
         if not person:
             return []
         out = []
-        if 'nistou' in person and person['nistou']:
-            out.append(f"nistou:{person['nistou']}")
-        if 'nistdiv' in person and person['nistdiv']:
-            out.append(f"nistdiv:{person['nistdiv']}")
-        if 'nistgrp' in person and person['nistgrp']:
-            out.append(f"nistgrp:{person['nistgrp']}")
+        ou_number = person.get('ouNumber')
+        if ou_number:
+            out.append(f"nistou:{ou_number}")
+        division_number = person.get('divisionNumber')
+        if division_number:
+            out.append(f"nistdiv:{division_number}")
+        group_number = person.get('groupNumber')
+        if group_number:
+            out.append(f"nistgrp:{group_number}")
         return out
 
     def create_record(self, name: str, shoulder: str = None,

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -733,11 +733,13 @@ class DBGroups(object):
         :param str shoulder:   the shoulder to prefix to the identifier.  The value usually controls
                                how the identifier is formed.
         """
-        # determine shoulder if not provided
         mintcfg = self._cli._cfg.get("group_id_minting", {})
         if not shoulder:
-            shoulder = self._cli._get_default_shoulder(mintcfg, self._cli._who)    # may raise NotAuthorized
-        elif not self._cli._authorized_for_shoulder(mintcfg, shoulder, self._cli._who):
+            if mintcfg:
+                shoulder = self._cli._get_default_shoulder(mintcfg, self._cli._who)
+            else:
+                shoulder = DEF_GROUPS_SHOULDER
+        elif mintcfg and not self._cli._authorized_for_shoulder(mintcfg, shoulder, self._cli._who):
             raise NotAuthorized(str(self._cli._who), f"create a group under the {shoulder}")
 
         return "{}:{}:{}".format(shoulder, owner, name)

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -1070,12 +1070,12 @@ class DBClient(ABC):
         if not person:
             return []
         out = []
-        if 'nistou' in person and person['nistou']:
-            out.append(f"nistou:{person['nistou']}")
-        if 'nistdiv' in person and person['nistdiv']:
-            out.append(f"nistdiv:{person['nistdiv']}")
-        if 'nistgrp' in person and person['nistgrp']:
-            out.append(f"nistgrp:{person['nistgrp']}")
+        if 'ouOrgID' in person and person['ouOrgID']:
+            out.append(f"nistou:{person['ouOrgID']}")
+        if 'divisionOrgID' in person and person['divisionOrgID']:
+            out.append(f"nistdiv:{person['divisionOrgID']}")
+        if 'groupOrgID' in person and person['groupOrgID']:
+            out.append(f"nistgrp:{person['groupOrgID']}")
         return out
 
     def create_record(self, name: str, shoulder: str = None,

--- a/python/nistoar/midas/dbio/base.py
+++ b/python/nistoar/midas/dbio/base.py
@@ -688,7 +688,7 @@ class DBGroups(object):
     def native(self):
         return self._cli._native
 
-    def create_group(self, name: str, foruser: str = None):
+    def create_group(self, name: str, foruser: str = None, shoulder: str = None):
         """
         create a new group for the given user.
         :param str name:     the name of the group to create
@@ -697,6 +697,8 @@ class DBGroups(object):
                              underlying :py:class:`DBClient` will be used.  Only a superuser (an identity
                              listed in the `superuser` config parameter) can create a group for another
                              user.
+        :param str shoulder: the shoulder to use for the new group identifier.  If not provided, the
+                             DBGroups default shoulder will be used.
         :raises AlreadyExists:  if the user has already defined a group with this name
         :raises NotAuthorized:  if the user is not authorized to create this group
         """
@@ -712,7 +714,7 @@ class DBGroups(object):
             foruser = self._cli.user_id
 
         out = Group({
-            "id": self._mint_id(self._shldr, name, foruser),   # may raise NotAuthorized
+            "id": self._mint_id(shoulder or self._shldr, name, foruser),   # may raise NotAuthorized
             "name": name,
             "owner": foruser,
             "members": [foruser],
@@ -821,16 +823,24 @@ class DBGroups(object):
 
         return out
 
-    def select_for_user(self, user_id: str) -> Iterator[Group]:
+    def _matches_shoulder(self, rec: Mapping, shoulder: str = None) -> bool:
+        if not shoulder:
+            return True
+        return rec.get('id', '').split(':', 1)[0] == shoulder
+
+    def select_for_user(self, user_id: str, shoulder: str = None) -> Iterator[Group]:
         """
         return all groups the user owns or is a direct member of.
+        :param str shoulder: if provided, only return groups with this identifier shoulder.
         """
         seen = set()
         for rec in self._cli._select_from_coll(GROUPS_COLL, owner=user_id):
+            if not self._matches_shoulder(rec, shoulder):
+                continue
             seen.add(rec['id'])
             yield Group(rec, self._cli)
         for rec in self._cli._select_prop_contains(GROUPS_COLL, 'members', user_id):
-            if rec['id'] not in seen:
+            if rec['id'] not in seen and self._matches_shoulder(rec, shoulder):
                 seen.add(rec['id'])
                 yield Group(rec, self._cli)
 

--- a/python/nistoar/midas/dbio/wsgi/group.py
+++ b/python/nistoar/midas/dbio/wsgi/group.py
@@ -45,7 +45,7 @@ class GroupService:
         self._groups: DBGroups = dbclient.groups
         self.log = log
 
-    def create_group(self, name: str, foruser: str = None) -> Group:
+    def create_group(self, name: str, foruser: str = None, shoulder: str = None) -> Group:
         """
         Use DBGroups.create_group to create a new group.
 
@@ -53,11 +53,12 @@ class GroupService:
         :param str foruser:  the identifier of the user to create the group for.  This user will be set as
                              the group's owner/administrator.  If not given, the user attached to the
                              underlying :py:class:`DBClient` will be used.
+        :param str shoulder: the identifier shoulder to use for the new group.
         :raises AlreadyExists:  if the user has already defined a group with this name
         :raises NotAuthorized:  if the user is not authorized to create this group
         :return: the newly created Group object
         """
-        return self._groups.create_group(name, foruser)
+        return self._groups.create_group(name, foruser, shoulder)
 
     def get_group(self, group_id: str) -> Group:
         """
@@ -121,10 +122,10 @@ class GroupService:
         grp.save()
         return True
 
-    def list_groups(self) -> list:
+    def list_groups(self, shoulder: str = None) -> list:
         """Return all groups the current user owns or belongs to."""
         user_id = self._cli.user_id
-        return [g.to_dict() for g in self._groups.select_for_user(user_id)]
+        return [g.to_dict() for g in self._groups.select_for_user(user_id, shoulder)]
 
 
 class GroupServiceFactory:
@@ -134,7 +135,11 @@ class GroupServiceFactory:
 
     def __init__(self, dbcli_factory: DBClientFactory, config: dict, log: Logger = None):
         self.dbcli_factory = dbcli_factory
-        self.config = config
+        self.config = config or {}
+        self.dbio_config = dict(self.config)
+        if isinstance(self.config.get("dbio"), Mapping):
+            self.dbio_config.update(self.config["dbio"])
+            self.dbio_config.pop("dbio", None)
         self.log = log
 
     def create_service_for(self, who: Agent) -> GroupService:
@@ -143,7 +148,7 @@ class GroupServiceFactory:
         """
         if who is None:
             who = Agent("dbio.group", Agent.USER, Agent.ANONYMOUS, Agent.PUBLIC)
-        dbcli = self.dbcli_factory.create_client("groups", config = self.config, foruser = who.actor)
+        dbcli = self.dbcli_factory.create_client("groups", config = self.dbio_config, foruser = who)
         return GroupService(dbcli, self.log)
 
 
@@ -166,7 +171,7 @@ class GroupSelectionHandler(DBIOHandler):
         GET /{shoulder} — list all groups the caller owns or belongs to.
         """
         try:
-            groups = self.svc.list_groups()
+            groups = self.svc.list_groups(self._shoulder)
             return self.send_json(groups, ashead=ashead)
         except NotAuthorized:
             return self.send_unauthorized()
@@ -195,7 +200,7 @@ class GroupSelectionHandler(DBIOHandler):
 
         foruser = data.get("foruser", None)
         try:
-            grp = self.svc.create_group(name, foruser)
+            grp = self.svc.create_group(name, foruser, self._shoulder)
             return self.send_json(grp.to_dict(), "Group Created", 201)
         except AlreadyExists as ex:
             return self.send_error_resp(400, "Already Exists", str(ex))
@@ -403,4 +408,3 @@ class MIDASGroupApp(ServiceApp):
         Return a function that can create a MIDASGroupApp.
         """
         return cls._factory()
-

--- a/python/nistoar/midas/dbio/wsgi/group.py
+++ b/python/nistoar/midas/dbio/wsgi/group.py
@@ -125,6 +125,11 @@ class GroupService:
         grp.save()
         return True
 
+    def list_groups(self) -> list:
+        """Return all groups the current user owns or belongs to."""
+        user_id = self._cli.user_id
+        return [g.to_dict() for g in self._groups.select_for_user(user_id)]
+
 
 class GroupServiceFactory:
     """
@@ -158,7 +163,17 @@ class GroupSelectionHandler(DBIOHandler):
         self._shoulder = shoulder
 
     def do_OPTIONS(self, path):
-        return self.send_options(["POST"])
+        return self.send_options(["GET", "POST"])
+
+    def do_GET(self, path, ashead=False):
+        """
+        GET /{shoulder} — list all groups the caller owns or belongs to.
+        """
+        try:
+            groups = self.svc.list_groups()
+            return self.send_json(groups, ashead=ashead)
+        except NotAuthorized:
+            return self.send_unauthorized()
 
     def do_POST(self, path):
         """

--- a/python/nistoar/midas/dbio/wsgi/project.py
+++ b/python/nistoar/midas/dbio/wsgi/project.py
@@ -1092,7 +1092,7 @@ class ProjectACLsHandler(ProjectRecordHandler):
             # remove the identity from the ACL
             try:
                 prec.acls.revoke_perm_from(parts[0], parts[1])
-                prec.save()
+                prec.save(dbio.ACLs.ADMIN)
                 return self.send_ok(message="ID removed")
             except dbio.NotAuthorized as ex:
                 return self.send_unauthorized()

--- a/python/nistoar/midas/export/exporters/csv_exporter.py
+++ b/python/nistoar/midas/export/exporters/csv_exporter.py
@@ -136,12 +136,13 @@ class CSVExporter(Exporter):
         else:
             # DMP CSV headers and data
             headers = [
-                "Name", "ID", "Type", "Owner", "Status_State", "Status_Action", 
-                "Status_CreatedDate", "Status_ModifiedDate", "Status_Message", 
-                "Title", "ProjectDescription", "StartDate", "DmpSearchable", 
-                "Grant_Source", "Grant_ID", "Keywords", "DataSize", "SizeUnit", 
-                "SoftwareDevelopment", "TechnicalResources", "DataDescription", 
-                "DataCategories", "PreservationDescription"
+                "Name", "ID", "Type", "Owner", "Status_State", "Status_Action",
+                "Status_CreatedDate", "Status_ModifiedDate", "Status_Message",
+                "Title", "ProjectDescription", "StartDate", "DmpSearchable",
+                "Grant_Source", "Grant_ID", "Keywords", "DataSize", "SizeUnit",
+                "SoftwareDevelopment", "TechnicalResources", "DataDescription",
+                "DataCategories", "PreservationDescription",
+                "DataSizeFrequency", "DataFilePaths"
             ]
             writer.writerow(headers)
             
@@ -187,7 +188,9 @@ class CSVExporter(Exporter):
                 "; ".join(data.get("technicalResources", [])),
                 data.get("dataDescription", "Not Provided"),
                 "; ".join(data.get("dataCategories", [])),
-                data.get("preservationDescription", "Not Provided")
+                data.get("preservationDescription", "Not Provided"),
+                data.get("dataSizeDescription") or "Not Provided",
+                "; ".join(s.strip() for s in data.get("pathsURLs", []))
             ]
         
         writer.writerow(row)

--- a/python/tests/nistoar/midas/dbio/test_group.py
+++ b/python/tests/nistoar/midas/dbio/test_group.py
@@ -84,18 +84,18 @@ class TestMIDASGroupApp(test.TestCase):
 
     def test_no_shoulder_provided(self):
         """
-        If we call /midas/group/ with no <shoulder>, we expect a 500 or 400
-        because group.py expects a shoulder.
+        GET /midas/group/ with no shoulder uses the default shoulder and returns 200.
         """
         path = ""
         req = {
             'REQUEST_METHOD': 'GET',
             'PATH_INFO': self.rootpath + path
         }
-        # This should fail because group.py checks for a shoulder
         hdlr = self.app.create_handler(req, self.start, path, test_agent)
         body = hdlr.handle()
-        self.assertIn("405 ", self.resp[0])
+        self.assertIn("200 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertIsInstance(resp, list)
 
     def test_create_group(self):
         """
@@ -119,6 +119,37 @@ class TestMIDASGroupApp(test.TestCase):
         # The ID can be "grp0:tester1:my-test-group" or similar
         self.assertIn("grp0:tester1:", resp['id'])
         self.assertEqual(resp['members'], ["tester1"])  # By default, the group is owned by user
+
+    def test_list_groups(self):
+        """
+        GET /midas/group/grp0 returns all groups the caller owns or belongs to.
+        """
+        path = "grp0"
+
+        # create two groups as test_agent (tester1)
+        for name in ["alpha", "beta"]:
+            req = {
+                'REQUEST_METHOD': 'POST',
+                'PATH_INFO': self.rootpath + path,
+                'wsgi.input': StringIO(json.dumps({"name": name}))
+            }
+            self.app.create_handler(req, self.start, path, test_agent).handle()
+            self.resp = []
+
+        # list groups
+        req = {
+            'REQUEST_METHOD': 'GET',
+            'PATH_INFO': self.rootpath + path
+        }
+        hdlr = self.app.create_handler(req, self.start, path, test_agent)
+        body = hdlr.handle()
+
+        self.assertIn("200 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertIsInstance(resp, list)
+        self.assertEqual(len(resp), 2)
+        names = {g['name'] for g in resp}
+        self.assertEqual(names, {"alpha", "beta"})
 
     def test_create_group_missing_name(self):
         """

--- a/python/tests/nistoar/midas/dbio/test_group.py
+++ b/python/tests/nistoar/midas/dbio/test_group.py
@@ -68,9 +68,10 @@ class TestMIDASGroupApp(test.TestCase):
         self.cfg = {
             "dbio": {
                 "superusers": ["adminuser"],
-            },
-            "group_id_minting": {
-                "default_shoulder": { "public": "grp0" }
+                "group_id_minting": {
+                    "default_shoulder": { "public": "grp0" },
+                    "allowed_shoulders": { "midas": ["grp0", "grp1"] }
+                }
             }
         }
         self.dbfact = InMemoryDBClientFactory({}, {})
@@ -120,6 +121,41 @@ class TestMIDASGroupApp(test.TestCase):
         self.assertIn("grp0:tester1:", resp['id'])
         self.assertEqual(resp['members'], ["tester1"])  # By default, the group is owned by user
 
+    def test_create_group_uses_requested_shoulder(self):
+        """
+        POST /midas/group/grp1 creates a grp1 group when the caller is authorized for that shoulder.
+        """
+        path = "grp1"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path,
+            'wsgi.input': StringIO(json.dumps({"name": "alternate-shoulder-group"}))
+        }
+
+        hdlr = self.app.create_handler(req, self.start, path, test_agent)
+        body = hdlr.handle()
+
+        self.assertIn("201 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertEqual(resp['name'], "alternate-shoulder-group")
+        self.assertIn("grp1:tester1:", resp['id'])
+
+    def test_create_group_rejects_unauthorized_shoulder(self):
+        """
+        POST /midas/group/grp2 is rejected when the caller is not authorized for that shoulder.
+        """
+        path = "grp2"
+        req = {
+            'REQUEST_METHOD': 'POST',
+            'PATH_INFO': self.rootpath + path,
+            'wsgi.input': StringIO(json.dumps({"name": "unauthorized-shoulder-group"}))
+        }
+
+        hdlr = self.app.create_handler(req, self.start, path, test_agent)
+        hdlr.handle()
+
+        self.assertIn("401 ", self.resp[0])
+
     def test_list_groups(self):
         """
         GET /midas/group/grp0 returns all groups the caller owns or belongs to.
@@ -150,6 +186,38 @@ class TestMIDASGroupApp(test.TestCase):
         self.assertEqual(len(resp), 2)
         names = {g['name'] for g in resp}
         self.assertEqual(names, {"alpha", "beta"})
+
+    def test_list_groups_filters_requested_shoulder(self):
+        """
+        GET /midas/group/{shoulder} returns only groups from that shoulder.
+        """
+        for path, name in [("grp0", "alpha"), ("grp1", "beta")]:
+            req = {
+                'REQUEST_METHOD': 'POST',
+                'PATH_INFO': self.rootpath + path,
+                'wsgi.input': StringIO(json.dumps({"name": name}))
+            }
+            self.app.create_handler(req, self.start, path, test_agent).handle()
+            self.resp = []
+
+        req = {
+            'REQUEST_METHOD': 'GET',
+            'PATH_INFO': self.rootpath + "grp0"
+        }
+        body = self.app.create_handler(req, self.start, "grp0", test_agent).handle()
+        self.assertIn("200 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertEqual([g['name'] for g in resp], ["alpha"])
+
+        self.resp = []
+        req = {
+            'REQUEST_METHOD': 'GET',
+            'PATH_INFO': self.rootpath + "grp1"
+        }
+        body = self.app.create_handler(req, self.start, "grp1", test_agent).handle()
+        self.assertIn("200 ", self.resp[0])
+        resp = self.body2dict(body)
+        self.assertEqual([g['name'] for g in resp], ["beta"])
 
     def test_create_group_missing_name(self):
         """
@@ -442,9 +510,9 @@ class TestMIDASGroupAppMongo(test.TestCase):
         self.cfg = {
             "dbio": {
                 "superusers": ["adminuser"],
-            },
-            "group_id_minting": {
-                "default_shoulder": { "public": "grp0" }
+                "group_id_minting": {
+                    "default_shoulder": { "public": "grp0" }
+                }
             }
         }
         self.dburl = os.environ['MONGO_TESTDB_URL']

--- a/python/tests/nistoar/midas/dbio/test_groups.py
+++ b/python/tests/nistoar/midas/dbio/test_groups.py
@@ -413,8 +413,8 @@ class TestVirtualGroups(test.TestCase):
 
     def test_all_groups_for_withMockPeopleService(self):
         staffdata = {
-            "nist0:ava1": { "nistou": "728", "nistdiv": "730" },
-            "nist0:alice": { "nistgrp": "999" }
+            "nist0:ava1": { "ouNumber": "728", "divisionNumber": "730" },
+            "nist0:alice": { "groupNumber": "999" }
         }
         pplsvc = MockPeopleService(staffdata)
         newcli = self.fact.create_client(base.DMP_PROJECTS, self.clientcfg, self.user)
@@ -437,8 +437,8 @@ class TestVirtualGroups(test.TestCase):
 
     def test_recache_user_groups_withMockPeopleService(self):
         staffdata = {
-            "nist0:ava1": { "nistou": "728", "nistdiv": "730" },
-            "nist0:alice": { "nistgrp": "999" }
+            "nist0:ava1": { "ouNumber": "728", "divisionNumber": "730" },
+            "nist0:alice": { "groupNumber": "999" }
         }
         pplsvc = MockPeopleService(staffdata)
         newcli = self.fact.create_client(base.DMP_PROJECTS, self.clientcfg, self.user)
@@ -469,11 +469,11 @@ class TestVirtualGroups(test.TestCase):
 
     def test_authorized_via_virtual_group(self):
         # Grant read access to a virtual group ID (nistou:728).
-        # A user whose NSD entry maps to nistou:728 should pass authorized(),
+        # A user whose NSD entry maps to ouNumber 728 should pass authorized(),
         # while a user in a different OU and a user absent from NSD should not.
         staffdata = {
-            "nist0:ava1": {"nistou": "728", "nistdiv": "730"},
-            "nist0:bob":  {"nistgrp": "999"},
+            "nist0:ava1": {"ouNumber": "728", "divisionNumber": "730"},
+            "nist0:bob":  {"groupNumber": "999"},
         }
         pplsvc = MockPeopleService(staffdata)
         cli = self.fact.create_client(base.DMP_PROJECTS, self.clientcfg, "alice")

--- a/python/tests/nistoar/midas/dbio/test_groups.py
+++ b/python/tests/nistoar/midas/dbio/test_groups.py
@@ -15,6 +15,9 @@ class TestGroup(test.TestCase):
             "group_id_minting": {
                 "default_shoulder": {
                     "public": "grp0"
+                },
+                "allowed_shoulders": {
+                    "public": ["grp0", "grp1"]
                 }
             }
         }
@@ -110,6 +113,9 @@ class TestDBGroups(test.TestCase):
             "group_id_minting": {
                 "default_shoulder": {
                     "public": "grp0"
+                },
+                "allowed_shoulders": {
+                    "public": ["grp0", "grp1"]
                 }
             }
         }
@@ -160,6 +166,14 @@ class TestDBGroups(test.TestCase):
         self.assertEqual(grp.id, "grp0:alice:friends")
         self.assertTrue(grp.is_member("alice"))
         self.assertTrue(not grp.is_member(self.user))
+
+    def test_create_group_requested_shoulder(self):
+        grp = self.dbg.create_group("collaborators", shoulder="grp1")
+
+        self.assertEqual(grp.name, "collaborators")
+        self.assertEqual(grp.owner, self.user)
+        self.assertEqual(grp.id, "grp1:nist0:ava1:collaborators")
+        self.assertIn(grp.id, self.fact._db[base.GROUPS_COLL])
 
     def test_get(self):
         self.assertIsNone(self.dbg.get("grp0:nist0:ava1:friends"))
@@ -328,6 +342,20 @@ class TestDBGroups(test.TestCase):
         self.assertIn(g2.id, ids)
         self.assertIn(g3.id, ids)   # member but not owner
         self.assertEqual(len(ids), 3)  # no duplicates
+
+        # filtering by shoulder should keep only matching group IDs
+        g4 = self.dbg.create_group("team-c", shoulder="grp1")
+        results = list(self.dbg.select_for_user(self.user, "grp0"))
+        ids = [g.id for g in results]
+        self.assertIn(g1.id, ids)
+        self.assertIn(g2.id, ids)
+        self.assertIn(g3.id, ids)
+        self.assertNotIn(g4.id, ids)
+        self.assertEqual(len(ids), 3)
+
+        results = list(self.dbg.select_for_user(self.user, "grp1"))
+        ids = [g.id for g in results]
+        self.assertEqual(ids, [g4.id])
 
         # user with no groups sees nothing
         stranger_cli = self.fact.create_client(base.DMP_PROJECTS, self.cfg, "stranger")

--- a/python/tests/nistoar/midas/dbio/test_groups.py
+++ b/python/tests/nistoar/midas/dbio/test_groups.py
@@ -311,6 +311,29 @@ class TestDBGroups(test.TestCase):
         self.assertIn(base.PUBLIC_GROUP, matches)
         self.assertEqual(len(matches), 4)
 
+    def test_select_for_user(self):
+        # two groups owned by self.user
+        g1 = self.dbg.create_group("team-a")
+        g2 = self.dbg.create_group("team-b")
+
+        # one group created by another user, with self.user added as member
+        other_cli = self.fact.create_client(base.DMP_PROJECTS, self.cfg, "other-user")
+        g3 = other_cli.groups.create_group("other-team")
+        g3.add_member(self.user)
+        g3.save()
+
+        results = list(self.dbg.select_for_user(self.user))
+        ids = [g.id for g in results]
+        self.assertIn(g1.id, ids)
+        self.assertIn(g2.id, ids)
+        self.assertIn(g3.id, ids)   # member but not owner
+        self.assertEqual(len(ids), 3)  # no duplicates
+
+        # user with no groups sees nothing
+        stranger_cli = self.fact.create_client(base.DMP_PROJECTS, self.cfg, "stranger")
+        results = list(stranger_cli.groups.select_for_user("stranger"))
+        self.assertEqual(len(results), 0)
+
 
 class MockPeopleService(base.PeopleService):
     def __init__(self, staffdata):

--- a/python/tests/nistoar/midas/export/exporters/test_csv_exporter.py
+++ b/python/tests/nistoar/midas/export/exporters/test_csv_exporter.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
-import tempfile
-import os
+import csv
+import io
+from pathlib import Path
 from nistoar.midas.export.exporters.csv_exporter import CSVExporter
 
 
@@ -30,106 +31,90 @@ class TestCSVExporter(unittest.TestCase):
         ]
         self.exporter = CSVExporter()
 
-    @patch('nistoar.midas.export.exporters.csv_exporter.preppy')
-    def test_render_csv_with_template(self, mock_preppy):
-        # Mock preppy module
-        mock_template = MagicMock()
-        mock_template.getOutput.return_value = "Name,ID,Type\nTest DMP 1,mdm1-test1,dmp\n"
-        mock_preppy.getModule.return_value = mock_template
+    def csv_rows(self, text):
+        return list(csv.reader(io.StringIO(text)))
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.prep', delete=False) as tmp_file:
-            tmp_file.write("test template")
-            template_path = tmp_file.name
-
-        try:
-            result = self.exporter.render(self.test_data, template_path)
-
-            self.assertIsInstance(result, dict)
-            self.assertEqual(result['format'], 'csv')
-            self.assertIn('text', result)
-            self.assertEqual(result['mimetype'], 'text/csv')
-            self.assertEqual(result['file_extension'], '.csv')
-            self.assertIn('Name,ID,Type', result['text'])
-
-            # Verify preppy was called correctly
-            mock_preppy.getModule.assert_called_once_with(template_path)
-            mock_template.getOutput.assert_called_once()
-
-        finally:
-            os.unlink(template_path)
-
-    @patch('nistoar.midas.export.exporters.csv_exporter.preppy')
-    def test_render_csv_without_template_dmp(self, mock_preppy):
-        # Mock preppy for default DMP template
-        mock_template = MagicMock()
-        mock_template.getOutput.return_value = "Name,ID,Type\nTest DMP 1,mdm1-test1,dmp\n"
-        mock_preppy.getModule.return_value = mock_template
-
-        result = self.exporter.render(self.test_data)
-
+    def test_render_csv_without_template_dmp(self):
+        result = self.exporter.render("json", self.test_data, "test-dmp")
         self.assertIsInstance(result, dict)
         self.assertEqual(result['format'], 'csv')
+        self.assertEqual(result['filename'], 'test-dmp.csv')
         self.assertIn('text', result)
         self.assertEqual(result['mimetype'], 'text/csv')
-        
-        # Should use default DMP template
-        mock_preppy.getModule.assert_called_once()
-        call_args = mock_preppy.getModule.call_args[0][0]
-        self.assertIn('dmp_csv_template.prep', call_args)
 
-    @patch('nistoar.midas.export.exporters.csv_exporter.preppy')
-    def test_render_csv_without_template_dap(self, mock_preppy):
-        # Modify test data for DAP type
-        dap_data = self.test_data.copy()
-        dap_data[0]['id'] = 'mds3-test1'
-        dap_data[0]['type'] = 'dap'
+        rows = self.csv_rows(result['text'])
+        self.assertEqual(rows[0][:3], ['Name', 'ID', 'Type'])
+        self.assertEqual(rows[1][0], 'Test DMP 1')
+        self.assertEqual(rows[1][1], 'mdm1-test1')
+        self.assertEqual(rows[1][2], 'DMP')
 
+    def test_render_csv_with_report_template(self):
         mock_template = MagicMock()
-        mock_template.getOutput.return_value = "Name,ID,Type\nTest DAP 1,mds3-test1,dap\n"
-        mock_preppy.getModule.return_value = mock_template
+        mock_template.get.return_value = "Name,ID,Type\nTest DMP 1,mdm1-test1,dmp\n"
+        template_path = Path("/tmp/export_report_csv_template.prep")
 
-        result = self.exporter.render(dap_data)
+        with patch.object(self.exporter, 'resolve_template_path', return_value=template_path), \
+             patch('nistoar.midas.export.exporters.csv_exporter.preppy.getModule',
+                   return_value=mock_template) as mock_get_module:
+            result = self.exporter.render(
+                "json", self.test_data[0], "test-report", "export_report_csv_template.prep")
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result['format'], 'csv')
-        
-        # Should use DAP template
-        mock_preppy.getModule.assert_called_once()
-        call_args = mock_preppy.getModule.call_args[0][0]
-        self.assertIn('dap_csv_template.prep', call_args)
+        self.assertEqual(result['filename'], 'test-report.csv')
+        self.assertEqual(result['text'], "Name,ID,Type\nTest DMP 1,mdm1-test1,dmp\n")
+        mock_get_module.assert_called_once_with(str(template_path))
+        mock_template.get.assert_called_once_with(self.test_data[0]['data'])
 
-    @patch('nistoar.midas.export.exporters.csv_exporter.preppy')
-    def test_render_csv_with_error(self, mock_preppy):
-        # Mock preppy to raise an exception
-        mock_preppy.getModule.side_effect = Exception("Template not found")
+    def test_render_csv_without_template_dap(self):
+        dap_data = [dict(self.test_data[0])]
+        dap_data[0]['id'] = 'mds3-test1'
+        dap_data[0]['type'] = 'dap'
+        dap_data[0]['data'] = {
+            'title': 'Test DAP 1',
+            'doi': 'doi:10.18434/mds3-test1',
+            'contactPoint': {'fn': 'Jane Smith', 'hasEmail': 'jane.smith@nist.gov'},
+            'keywords': ['test', 'data']
+        }
 
-        with self.assertRaises(Exception) as context:
-            self.exporter.render(self.test_data)
+        result = self.exporter.render("json", dap_data, "test-dap")
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['format'], 'csv')
+
+        rows = self.csv_rows(result['text'])
+        self.assertEqual(rows[0][:3], ['Name', 'ID', 'Type'])
+        self.assertEqual(rows[0][10], 'DOI')
+        self.assertEqual(rows[1][1], 'mds3-test1')
+        self.assertEqual(rows[1][2], 'DAP')
+
+    def test_render_csv_with_error(self):
+        with patch.object(self.exporter, 'resolve_template_path',
+                          return_value=Path("/tmp/export_report_csv_template.prep")), \
+             patch('nistoar.midas.export.exporters.csv_exporter.preppy.getModule',
+                   side_effect=Exception("Template not found")):
+            with self.assertRaises(Exception) as context:
+                self.exporter.render(
+                    "json", self.test_data[0], "test-report", "export_report_csv_template.prep")
 
         self.assertIn("Template not found", str(context.exception))
 
+    def test_render_rejects_unsupported_input_type(self):
+        with self.assertRaises(TypeError) as context:
+            self.exporter.render("xml", self.test_data, "test")
+        self.assertIn("unsupported payload type", str(context.exception))
+
     def test_render_empty_data(self):
-        with patch('nistoar.midas.export.exporters.csv_exporter.preppy') as mock_preppy:
-            mock_template = MagicMock()
-            mock_template.getOutput.return_value = "Name,ID,Type\n"
-            mock_preppy.getModule.return_value = mock_template
+        with self.assertRaises(TypeError) as context:
+            self.exporter.render("json", [], "empty")
+        self.assertIn("CSVExporter expects", str(context.exception))
 
-            result = self.exporter.render([])
+    def test_render_unknown_record_id_defaults_to_dmp(self):
+        unknown_data = [dict(self.test_data[0])]
+        unknown_data[0]['id'] = 'unknown-test'
 
-            self.assertIsInstance(result, dict)
-            self.assertEqual(result['format'], 'csv')
-            self.assertEqual(result['text'], "Name,ID,Type\n")
-
-    def test_detect_record_type_dmp(self):
-        self.assertEqual(self.exporter._detect_record_type(self.test_data), 'dmp')
-
-    def test_detect_record_type_dap(self):
-        dap_data = [{'id': 'mds3-test', 'type': 'dap'}]
-        self.assertEqual(self.exporter._detect_record_type(dap_data), 'dap')
-
-    def test_detect_record_type_default(self):
-        unknown_data = [{'id': 'unknown-test'}]
-        self.assertEqual(self.exporter._detect_record_type(unknown_data), 'dmp')
+        result = self.exporter.render("json", unknown_data, "test-default")
+        rows = self.csv_rows(result['text'])
+        self.assertEqual(rows[1][2], 'DMP')
 
     def test_dmp_csv_new_fields(self):
         record = {

--- a/python/tests/nistoar/midas/export/exporters/test_csv_exporter.py
+++ b/python/tests/nistoar/midas/export/exporters/test_csv_exporter.py
@@ -131,6 +131,40 @@ class TestCSVExporter(unittest.TestCase):
         unknown_data = [{'id': 'unknown-test'}]
         self.assertEqual(self.exporter._detect_record_type(unknown_data), 'dmp')
 
+    def test_dmp_csv_new_fields(self):
+        record = {
+            'id': 'mdm1-test-fields',
+            'name': 'Test DMP',
+            'owner': 'testuser',
+            'status': {},
+            'meta': {},
+            'data': {
+                'dataSizeDescription': 'Annual',
+                'pathsURLs': [' /data/project ', ' https://example.com/data '],
+            }
+        }
+        result = self.exporter.render_json(record, 'test')
+        text = result['text']
+        self.assertIn('DataSizeFrequency', text)
+        self.assertIn('Annual', text)
+        self.assertIn('DataFilePaths', text)
+        self.assertIn('/data/project; https://example.com/data', text)
+
+    def test_dmp_csv_empty_size_description_shows_not_provided(self):
+        record = {
+            'id': 'mdm1-test-empty',
+            'name': 'Test DMP',
+            'owner': 'testuser',
+            'status': {},
+            'meta': {},
+            'data': {'dataSizeDescription': ''}
+        }
+        result = self.exporter.render_json(record, 'test')
+        # empty string must not silently pass through as a blank cell
+        rows = list(result['text'].splitlines())
+        data_row = rows[1]
+        self.assertIn('Not Provided', data_row)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/nistoar/midas/export/test_export_flow.py
+++ b/python/tests/nistoar/midas/export/test_export_flow.py
@@ -291,6 +291,7 @@ class ExportFlowProjectRecordTest(test.TestCase):
             "keywords": ["materials science", "data management", "testing", "metadata"],
             "dataSize": 500.5,
             "sizeUnit": "GB",
+            "dataSizeDescription": "Annual",
             "softwareDevelopment": {
                 "development": "yes",
                 "softwareUse": "Python scripts for data analysis",
@@ -364,6 +365,10 @@ class ExportFlowProjectRecordTest(test.TestCase):
         self.assertIn("NSF", csv_content)
         self.assertIn("500.5", csv_content)
         self.assertIn("materials science", csv_content)
+        self.assertIn("DataSizeFrequency", csv_content)
+        self.assertIn("Annual", csv_content)
+        self.assertIn("DataFilePaths", csv_content)
+        self.assertIn("https://data.nist.gov/test-project", csv_content)
 
     @patch("nistoar.midas.export.exporters.csv_exporter.preppy.getModule")
     def test_export_csv_single_dap(self, mock_get_module):


### PR DESCRIPTION
Add DataSizeFrequency and DataFilePaths to DMP CSV export

Two fields present in the DMP data model were missing from the CSV export, creating a discrepancy with the PDF version that was reported by users:

DataSizeFrequency (dataSizeDescription): the PDF correctly shows "1 Annual GB" while the CSV only showed "1 GB", dropping the annual vs. one-time qualifier entirely.
DataFilePaths (pathsURLs): the PDF includes a "File path(s) / URL(s) for where data will be saved" section that was absent from the CSV. This field is actively used — real records contain NIST network paths, ResData locations, and external URLs.
Both columns are appended at the end of the row to avoid breaking any existing consumers that parse by column index.

A few edge cases handled beyond the simple addition:

dataSizeDescription can be an empty string in existing records (not just absent) — both cases now render as "Not Provided" rather than a blank cell
pathsURLs entries in real data frequently have leading/trailing whitespace — entries are stripped before joining with "; "
Tests: two new focused unit tests cover the whitespace stripping and empty-string behavior; the existing test_export_csv_single_dmp flow test has been updated with dataSizeDescription in its fixture and assertions on both new columns.